### PR TITLE
Update masks to trichotomy: none, cotton, filtered

### DIFF
--- a/src/components/calculator/ActivityRiskControls.tsx
+++ b/src/components/calculator/ActivityRiskControls.tsx
@@ -140,7 +140,7 @@ const maskPopover = (
   <Popover id="popover-basic">
     <Popover.Title as="h3">Masks</Popover.Title>
     <Popover.Content>
-      For more details on masks, see&nbsp;
+      For more details on masks, see{" "}
       <Link to="/paper/14-research-sources#masks" target="_blank">
         research sources
       </Link>

--- a/src/components/calculator/ActivityRiskControls.tsx
+++ b/src/components/calculator/ActivityRiskControls.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { Popover } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
 
 import { SelectControl } from './SelectControl'
 import {
@@ -92,6 +94,7 @@ export const ActivityRiskControls: React.FunctionComponent<{
       <SelectControl
         id="theirMask"
         label="Their mask"
+        popover={maskPopover}
         data={data}
         setter={setter}
         source={TheirMask}
@@ -99,6 +102,7 @@ export const ActivityRiskControls: React.FunctionComponent<{
       <SelectControl
         id="yourMask"
         label="Your mask"
+        popover={maskPopover}
         data={data}
         setter={setter}
         source={YourMask}
@@ -131,3 +135,15 @@ export const ActivityRiskControls: React.FunctionComponent<{
     </React.Fragment>
   )
 }
+
+const maskPopover = (
+  <Popover id="popover-basic">
+    <Popover.Title as="h3">Masks</Popover.Title>
+    <Popover.Content>
+      For more details on masks, see&nbsp;
+      <Link to="/paper/14-research-sources#masks" target="_blank">
+        research sources
+      </Link>
+    </Popover.Content>
+  </Popover>
+)

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -21,23 +21,23 @@ describe('calculate', () => {
 
     const response = calculate(data)
     // average * 2 people * outdoor * 1 hr * their mask * your mask
-    expect(response).toBe(((((0.006 * 2) / 10) * 0.06) / 2 / 8) * 1e6)
+    expect(response).toBe(((((0.006 * 2) / 20) * 0.06) / 4 / 1) * 1e6)
   })
 
   it.each`
     scenario                                                | result
-    ${'Outdoor masked hangout with 2 people'}               | ${4.5}
+    ${'Outdoor masked hangout with 2 people'}               | ${9}
     ${'Indoor unmasked hangout with 2 people'}              | ${720}
     ${'Car ride with 1 person for 15 mins'}                 | ${90}
     ${'Physically intimate with person'}                    | ${2880}
-    ${'Grocery store for 60 minutes'}                       | ${90}
-    ${'Plane ride'}                                         | ${540}
+    ${'Grocery store for 60 minutes'}                       | ${180}
+    ${'Plane ride'}                                         | ${1080}
     ${'Eating in restaurant, outdoors'}                     | ${202.5}
     ${'Eating in restaurant, indoors'}                      | ${4050}
     ${'Going to bar'}                                       | ${27000}
-    ${'Large outdoor party: masked with 250 people'}        | ${1687.5}
+    ${'Large outdoor party: masked with 250 people'}        | ${3375}
     ${'Small indoor party: unmasked with 25 people'}        | ${27000}
-    ${'Outdoor, masked hangout with person who has COVID'}  | ${375}
+    ${'Outdoor, masked hangout with person who has COVID'}  | ${750}
     ${'Indoor, unmasked hangout with person who has COVID'} | ${60000}
   `('should return $result for $scenario', ({ scenario, result }) => {
     const data: CalculatorData = {

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -118,7 +118,7 @@ export const Distance: { [key: string]: FormValue } = {
 
 const noneLabel = 'No mask or poorly-worn mask'
 const basicLabel = 'Cotton mask, bandana, or buff'
-const filteredLabel = 'Surgical mask, PM2.5, or N95'
+const filteredLabel = 'Surgical mask, mask with filter insert, or N95'
 export const TheirMask: { [key: string]: FormValue } = {
   none: formValue(noneLabel, 1.0),
   basic: formValue(basicLabel, 0.25),

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -118,7 +118,7 @@ export const Distance: { [key: string]: FormValue } = {
 
 const noneLabel = 'No mask or poorly-worn mask'
 const basicLabel = 'Cotton mask, bandana, or buff'
-const filteredLabel = 'Surgical mask, mask with filter insert, or N95'
+const filteredLabel = 'Surgical mask or mask with PM2.5 filter insert'
 export const TheirMask: { [key: string]: FormValue } = {
   none: formValue(noneLabel, 1.0),
   basic: formValue(basicLabel, 0.25),

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -3,6 +3,10 @@ export interface FormValue {
   multiplier: number
 }
 
+const formValue = function (label: string, multiplier: number): FormValue {
+  return { label, multiplier }
+}
+
 export const RiskProfile: { [key: string]: FormValue } = {
   average: {
     label: 'An average person in your area',
@@ -111,22 +115,19 @@ export const Distance: { [key: string]: FormValue } = {
   sixFt: { label: '6+ feet apart', multiplier: 0.5 },
   tenFt: { label: '10+ feet apart', multiplier: 0.25 },
 }
+
+const noneLabel = 'No mask or poorly-worn mask'
+const basicLabel = 'Cotton mask, bandana, or buff'
+const filteredLabel = 'Surgical mask, PM2.5, or N95'
 export const TheirMask: { [key: string]: FormValue } = {
-  none: { label: 'No mask or poorly-worn mask', multiplier: 1 },
-  masked: {
-    label: 'High-quality mask (surgical or similar)',
-    multiplier: 0.25,
-  },
+  none: formValue(noneLabel, 1.0),
+  basic: formValue(basicLabel, 0.25),
+  filtered: formValue(filteredLabel, 0.25),
 }
 export const YourMask: { [key: string]: FormValue } = {
-  none: {
-    label: 'No mask or poorly-worn mask',
-    multiplier: 1,
-  },
-  masked: {
-    label: 'High-quality mask (surgical or similar)',
-    multiplier: 0.5,
-  },
+  none: formValue(noneLabel, 1.0),
+  basic: formValue(basicLabel, 1.0),
+  filtered: formValue(filteredLabel, 0.5),
 }
 export const Voice: { [key: string]: FormValue } = {
   silent: {

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -21,8 +21,8 @@ export const prepopulated: {
     setting: 'outdoor',
     distance: 'normal',
     duration: 60,
-    theirMask: 'masked',
-    yourMask: 'masked',
+    theirMask: 'basic',
+    yourMask: 'basic',
     voice: 'normal',
   },
 
@@ -74,7 +74,7 @@ export const prepopulated: {
     distance: 'sixFt',
     duration: 60,
     theirMask: 'none',
-    yourMask: 'masked',
+    yourMask: 'basic',
     voice: 'silent',
   },
 
@@ -86,8 +86,8 @@ export const prepopulated: {
     setting: 'indoor',
     distance: 'sixFt',
     duration: 360,
-    theirMask: 'masked',
-    yourMask: 'masked',
+    theirMask: 'basic',
+    yourMask: 'basic',
     voice: 'silent',
   },
 
@@ -138,8 +138,8 @@ export const prepopulated: {
     setting: 'outdoor',
     distance: 'normal',
     duration: 180,
-    theirMask: 'masked',
-    yourMask: 'masked',
+    theirMask: 'basic',
+    yourMask: 'basic',
     voice: 'normal',
   },
 
@@ -164,8 +164,8 @@ export const prepopulated: {
     setting: 'outdoor',
     distance: 'normal',
     duration: 60,
-    theirMask: 'masked',
-    yourMask: 'masked',
+    theirMask: 'basic',
+    yourMask: 'basic',
     voice: 'normal',
   },
 


### PR DESCRIPTION
Fixes: #137

Updates mask labels to be clear and user-friendly. Links from calculator to relevant research source section. Clearly lists cotton masks as "basic" masks, and reduces wearer protection from 2x to 1x for these.

I think this is sufficient for #159 (the wording is clear enough to answer most of the user questions we're seeing). I added a popover box to link to the relevant research section. Note that the research sources section cites Chu and states 2x wearer protection for basic masks while the calculator is using 1x.