### PR TITLE
Use percentage points (not %) as units of increase in risk

### DIFF
--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -29,7 +29,7 @@ function tooManyPoints(points: number): boolean {
 function pointsPerWeekToAnnual(points: number): string {
   return showPoints(points)
     ? fixedPointPrecisionPercent(1 - (1 - points * 1e-6) ** 52)
-    : '—%'
+    : '—'
 }
 
 function maybeGreater(points: number): string {
@@ -87,9 +87,10 @@ export function ExplanationCard(props: { points: number }): React.ReactElement {
         with these people.
       </p>
       <p>
-        If you did this once per week, you would have an additional{' '}
-        {pointsPerWeekToAnnual(points)}-or-so chance of getting COVID this year
-        (<i>not</i> including your risk from everything else you do!)
+        If you did this once per week, you would have
+        {' '}{pointsPerWeekToAnnual(points)}-or-so more chance (percentage points)
+        of getting COVID this year (<i>not</i> including your risk from everything
+        else you do!)
       </p>
     </Card>
   )


### PR DESCRIPTION
I am not totally sure that this is correct: I am not sure whether the number provided here is supposed to be an increase from e.g. 5% total risk to 15%, or from 5% to 5.5%. I assume that it is the former (percentage points), but haven't checked that 
the calculation (that I haven't touched) is a calculation of percentage points.

Whether or not I am correct, this paragraph should be made less ambiguous, as there is a big difference between 5.5% and 15% total risk, and people could interpret a 2% _relative_ increase as very small (missing that it is a 2% _absolute_ increase).

<img width="765" alt="Screenshot 2020-09-02 at 14 48 07" src="https://user-images.githubusercontent.com/44967334/91992945-acb35800-ed2c-11ea-8e1d-febeda24b00b.png">

Reviewers: if you like the change, please consider whether the sentence could be phrased more neatly or more clearly.