### PR TITLE
Add tildes to risk allocation

### DIFF
--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -114,14 +114,14 @@ const budgetConsumption = (points: number, budget: number) => {
     return (
       <p>
         Doing this activity once would use up your entire risk allocation for{' '}
-        {weeksConsumed} {Number.parseInt(weeksConsumed) > 1 ? 'weeks' : 'week'}.
+        ~{weeksConsumed} {Number.parseInt(weeksConsumed) > 1 ? 'weeks' : 'week'}.
       </p>
     )
   }
   return (
     <p>
       Doing this activity once would use up{' '}
-      {fixedPointPrecision((points / weekBudget) * 100)}% of your risk
+      ~{fixedPointPrecision((points / weekBudget) * 100)}% of your risk
       allocation for one week.
     </p>
   )


### PR DESCRIPTION
Suggest more clearly that we're rounding to one sig fig in indicating how much risk allocation one is using up.