### PR TITLE
Set CI to fail if eslint turns up warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: bahmutov/npm-install@v1
-    - run: yarn lint
+    - run: yarn lint --max-warnings 0
   typecheck:
     runs-on: ubuntu-latest
 

--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -113,15 +113,15 @@ const budgetConsumption = (points: number, budget: number) => {
     const weeksConsumed = fixedPointPrecision(points / weekBudget)
     return (
       <p>
-        Doing this activity once would use up your entire risk allocation for{' '}
-        ~{weeksConsumed} {Number.parseInt(weeksConsumed) > 1 ? 'weeks' : 'week'}.
+        Doing this activity once would use up your entire risk allocation for ~
+        {weeksConsumed} {Number.parseInt(weeksConsumed) > 1 ? 'weeks' : 'week'}.
       </p>
     )
   }
   return (
     <p>
-      Doing this activity once would use up{' '}
-      ~{fixedPointPrecision((points / weekBudget) * 100)}% of your risk
+      Doing this activity once would use up ~
+      {fixedPointPrecision((points / weekBudget) * 100)}% of your risk
       allocation for one week.
     </p>
   )

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -145,8 +145,7 @@ export const RiskProfile: { [key: string]: FormValue } = {
     multiplier:
       6 *
       Interaction.oneTime.multiplier *
-      (2 + 10 * Distance.sixFt.multiplier *
-      Voice.loud.multiplier)
+      (2 + 10 * Distance.sixFt.multiplier * Voice.loud.multiplier),
   },
   hasCovid: {
     label: 'Has COVID',


### PR DESCRIPTION
Submitting code with lint warnings results in degraded code standardization.
These are usually trivially fixable with `yarn fix`
Running `yarn fix` later results in PR's that change unrelated files.