### PR TITLE
Add query variables for easy linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node-sass": "^4.14.1",
     "popper.js": "^1.16.1",
     "prop-types": "^15.6.0",
+    "query-string": "^6.13.5",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
@@ -21,7 +22,8 @@
     "react-helmet-async": "^1.0.6",
     "react-icons": "^3.11.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "^4.0.0-next.64"
+    "react-scripts": "^4.0.0-next.64",
+    "use-query-params": "^1.1.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   BrowserRouter as Router,
   Switch,
 } from 'react-router-dom'
+import { QueryParamProvider } from 'use-query-params'
 
 import { PageViews } from 'components/Analytics'
 import { Footer } from 'components/Footer'
@@ -25,107 +26,109 @@ export const App = (): React.ReactElement => {
   return (
     <HelmetProvider>
       <Router>
-        <PageViews />
-        <Helmet>
-          <link
-            href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Roboto+Slab:wght@500&display=swap"
-            rel="stylesheet"
-          />
-        </Helmet>
+        <QueryParamProvider ReactRouterRoute={Route}>
+          <PageViews />
+          <Helmet>
+            <link
+              href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Roboto+Slab:wght@500&display=swap"
+              rel="stylesheet"
+            />
+          </Helmet>
 
-        <ScrollToTop />
+          <ScrollToTop />
 
-        <Container>
-          <Navbar expand="md">
-            <Navbar.Brand href="/">microCOVID Project</Navbar.Brand>
-            <Navbar.Toggle aria-controls="basic-navbar-nav" />
-            <Navbar.Collapse id="basic-navbar-nav">
-              <Nav className="ml-auto">
-                <Nav.Item>
-                  <NavLink
-                    to="/"
-                    className="nav-link"
-                    exact
-                    activeClassName="active"
-                  >
-                    Calculator
-                  </NavLink>
-                </Nav.Item>
+          <Container>
+            <Navbar expand="md">
+              <Navbar.Brand href="/">microCOVID Project</Navbar.Brand>
+              <Navbar.Toggle aria-controls="basic-navbar-nav" />
+              <Navbar.Collapse id="basic-navbar-nav">
+                <Nav className="ml-auto">
+                  <Nav.Item>
+                    <NavLink
+                      to="/"
+                      className="nav-link"
+                      exact
+                      activeClassName="active"
+                    >
+                      Calculator
+                    </NavLink>
+                  </Nav.Item>
 
-                <Nav.Item>
-                  <NavLink
-                    to="/about"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    About
-                  </NavLink>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavDropdown title="White Paper" id="basic-nav-dropdown">
-                    <NavDropdown.Item href="/paper">
-                      Table of Contents
-                    </NavDropdown.Item>
-                    <NavDropdown.Item href="/paper/all">
-                      All In One Page
-                    </NavDropdown.Item>
-                    {Object.keys(pages).map((pageId, pageIndex) => (
-                      <NavDropdown.Item
-                        href={`/paper/${pageId}`}
-                        key={pageIndex}
-                      >
-                        {pageIndex + 1}. {pages[pageId].shortTitle}
+                  <Nav.Item>
+                    <NavLink
+                      to="/about"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      About
+                    </NavLink>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavDropdown title="White Paper" id="basic-nav-dropdown">
+                      <NavDropdown.Item href="/paper">
+                        Table of Contents
                       </NavDropdown.Item>
-                    ))}
-                  </NavDropdown>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavLink
-                    to="/spreadsheet"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    Spreadsheet
-                  </NavLink>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavLink
-                    to="/contact"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    Contact Us
-                  </NavLink>
-                </Nav.Item>
-              </Nav>
-            </Navbar.Collapse>
-          </Navbar>
-          <Switch>
-            <Route path="/calculator">
-              <Redirect to={{ pathname: '/' }} />
-            </Route>
-            <Route path="/about">
-              <About />
-            </Route>
-            <Route path="/paper/:id">
-              <Paper />
-            </Route>
-            <Route exact path="/paper">
-              <PaperTOC />
-            </Route>
-            <Route path="/spreadsheet">
-              <Spreadsheet />
-            </Route>
-            <Route path="/contact">
-              <Contact />
-            </Route>
-            <Route path="/">
-              <Calculator />
-            </Route>
-          </Switch>
-        </Container>
+                      <NavDropdown.Item href="/paper/all">
+                        All In One Page
+                      </NavDropdown.Item>
+                      {Object.keys(pages).map((pageId, pageIndex) => (
+                        <NavDropdown.Item
+                          href={`/paper/${pageId}`}
+                          key={pageIndex}
+                        >
+                          {pageIndex + 1}. {pages[pageId].shortTitle}
+                        </NavDropdown.Item>
+                      ))}
+                    </NavDropdown>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavLink
+                      to="/spreadsheet"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      Spreadsheet
+                    </NavLink>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavLink
+                      to="/contact"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      Contact Us
+                    </NavLink>
+                  </Nav.Item>
+                </Nav>
+              </Navbar.Collapse>
+            </Navbar>
+            <Switch>
+              <Route path="/calculator">
+                <Redirect to={{ pathname: '/' }} />
+              </Route>
+              <Route path="/about">
+                <About />
+              </Route>
+              <Route path="/paper/:id">
+                <Paper />
+              </Route>
+              <Route exact path="/paper">
+                <PaperTOC />
+              </Route>
+              <Route path="/spreadsheet">
+                <Spreadsheet />
+              </Route>
+              <Route path="/contact">
+                <Contact />
+              </Route>
+              <Route path="/">
+                <Calculator />
+              </Route>
+            </Switch>
+          </Container>
 
-        <Footer />
+          <Footer />
+        </QueryParamProvider>
       </Router>
     </HelmetProvider>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
 
-
 import { PageViews } from 'components/Analytics'
 import { Footer } from 'components/Footer'
 import { ScrollToTop } from 'components/ScrollToTop'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import {
   BrowserRouter as Router,
   Switch,
 } from 'react-router-dom'
+import { QueryParamProvider } from 'use-query-params'
+
 
 import { PageViews } from 'components/Analytics'
 import { Footer } from 'components/Footer'
@@ -24,98 +26,100 @@ export const App = (): React.ReactElement => {
   return (
     <HelmetProvider>
       <Router>
-        <PageViews />
-        <Helmet>
-          <link
-            href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Roboto+Slab:wght@500&display=swap"
-            rel="stylesheet"
-          />
-        </Helmet>
+        <QueryParamProvider ReactRouterRoute={Route}>
+          <PageViews />
+          <Helmet>
+            <link
+              href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Roboto+Slab:wght@500&display=swap"
+              rel="stylesheet"
+            />
+          </Helmet>
 
-        <ScrollToTop />
+          <ScrollToTop />
 
-        <Container>
-          <Navbar expand="md">
-            <Navbar.Brand href="/">microCOVID Project</Navbar.Brand>
-            <Navbar.Toggle aria-controls="basic-navbar-nav" />
-            <Navbar.Collapse id="basic-navbar-nav">
-              <Nav className="ml-auto">
-                <Nav.Item>
-                  <NavLink
-                    to="/"
-                    className="nav-link"
-                    exact
-                    activeClassName="active"
-                  >
-                    Calculator
-                  </NavLink>
-                </Nav.Item>
+          <Container>
+            <Navbar expand="md">
+              <Navbar.Brand href="/">microCOVID Project</Navbar.Brand>
+              <Navbar.Toggle aria-controls="basic-navbar-nav" />
+              <Navbar.Collapse id="basic-navbar-nav">
+                <Nav className="ml-auto">
+                  <Nav.Item>
+                    <NavLink
+                      to="/"
+                      className="nav-link"
+                      exact
+                      activeClassName="active"
+                    >
+                      Calculator
+                    </NavLink>
+                  </Nav.Item>
 
-                <Nav.Item>
-                  <NavLink
-                    to="/about"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    About
-                  </NavLink>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavLink
-                    to="/paper"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    White Paper
-                  </NavLink>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavLink
-                    to="/spreadsheet"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    Spreadsheet
-                  </NavLink>
-                </Nav.Item>
-                <Nav.Item>
-                  <NavLink
-                    to="/contact"
-                    className="nav-link"
-                    activeClassName="active"
-                  >
-                    Contact Us
-                  </NavLink>
-                </Nav.Item>
-              </Nav>
-            </Navbar.Collapse>
-          </Navbar>
-          <Switch>
-            <Route path="/calculator">
-              <Redirect to={{ pathname: '/' }} />
-            </Route>
-            <Route path="/about">
-              <About />
-            </Route>
-            <Route path="/paper/:id">
-              <Paper />
-            </Route>
-            <Route exact path="/paper">
-              <PaperTOC />
-            </Route>
-            <Route path="/spreadsheet">
-              <Spreadsheet />
-            </Route>
-            <Route path="/contact">
-              <Contact />
-            </Route>
-            <Route path="/">
-              <Calculator />
-            </Route>
-          </Switch>
-        </Container>
+                  <Nav.Item>
+                    <NavLink
+                      to="/about"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      About
+                    </NavLink>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavLink
+                      to="/paper"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      White Paper
+                    </NavLink>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavLink
+                      to="/spreadsheet"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      Spreadsheet
+                    </NavLink>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <NavLink
+                      to="/contact"
+                      className="nav-link"
+                      activeClassName="active"
+                    >
+                      Contact Us
+                    </NavLink>
+                  </Nav.Item>
+                </Nav>
+              </Navbar.Collapse>
+            </Navbar>
+            <Switch>
+              <Route path="/calculator">
+                <Redirect to={{ pathname: '/' }} />
+              </Route>
+              <Route path="/about">
+                <About />
+              </Route>
+              <Route path="/paper/:id">
+                <Paper />
+              </Route>
+              <Route exact path="/paper">
+                <PaperTOC />
+              </Route>
+              <Route path="/spreadsheet">
+                <Spreadsheet />
+              </Route>
+              <Route path="/contact">
+                <Contact />
+              </Route>
+              <Route path="/">
+                <Calculator />
+              </Route>
+            </Switch>
+          </Container>
 
-        <Footer />
+          <Footer />
+        </QueryParamProvider>
       </Router>
     </HelmetProvider>
   )

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -8,7 +8,7 @@ export const ScrollToTop = (): null => {
     if (location.hash === '') {
       window.scrollTo(0, 0)
     }
-  }, [location])
+  }, [location.pathname, location.hash])
 
   return null
 }

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -55,6 +55,9 @@ export const defaultValues: CalculatorData = {
   voice: '',
 }
 
+// These are the variables exposed via query parameters
+export type QueryData = Partial<CalculatorData>
+
 // Replace any values that no longer exist with empty string (nothing selected).
 // This is used when restoring a previous saved scenario, in case we changed
 // the model in the meantime.

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,10 +1,10 @@
 import { isEmpty, pickBy } from 'lodash'
 import { QueryParamConfigMap } from 'serialize-query-params'
-import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
+import { NumberParam, StringParam } from 'use-query-params'
 
 import { CalculatorData, QueryData, defaultValues } from './calculate'
 
-const queryConfig: QueryParamConfigMap = {
+export const queryConfig: QueryParamConfigMap = {
   topLocation: StringParam,
   subLocation: StringParam,
 
@@ -20,20 +20,18 @@ const queryConfig: QueryParamConfigMap = {
   voice: StringParam,
 }
 
+//
 export const filterParams = (data: CalculatorData): QueryData => {
   const filterData = { ...data }
-  let key: keyof CalculatorData
-  for (key in filterData) {
-    if (!(key in queryConfig) || data[key] === defaultValues[key]) {
-      delete filterData[key]
-    }
-  }
-  return filterData
+  return pickBy(filterData, (v, k) => {
+    const fk = k as keyof CalculatorData
+    return k in queryConfig && v !== defaultValues[fk]
+  })
 }
 
-// This method chooses between existing calulator data (either defaults or from a
-// saved model) or the ones specified through query parameters.
-export const useParams = (
+// Choose between data from the query params or localstorage.
+// This method returns queryData if any valid key exists, otherwise, it returns calcData
+export const useQueryDataIfPresent = (
   queryData: QueryData,
   calcData: CalculatorData,
 ): CalculatorData => {
@@ -43,8 +41,4 @@ export const useParams = (
   } else {
     return { ...defaultValues, ...queryData }
   }
-}
-
-export const QueryParams = (): ReturnType<typeof useQueryParams> => {
-  return useQueryParams(queryConfig)
 }

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,13 +1,11 @@
-import { QueryParamConfig } from 'serialize-query-params'
+import { QueryParamConfigMap } from 'serialize-query-params'
 import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
 
 import { CalculatorData, defaultValues } from './calculate'
 
 export type QueryData = Partial<CalculatorData>
 
-const queryConfig: {
-  [key: string]: QueryParamConfig<any, any>
-} = {
+const queryConfig: QueryParamConfigMap = {
   topLocation: StringParam,
   subLocation: StringParam,
 
@@ -34,6 +32,6 @@ export const filterParams = (data: CalculatorData): QueryData => {
   return filterData
 }
 
-export const QueryParams = () => {
+export const QueryParams = (): ReturnType<typeof useQueryParams> => {
   return useQueryParams(queryConfig)
 }

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,42 +1,39 @@
-import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
 import { QueryParamConfig } from 'serialize-query-params'
+import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
 
 import { CalculatorData, defaultValues } from './calculate'
 
 export type QueryData = Partial<CalculatorData>
 
 const queryConfig: {
-	[key: string]: QueryParamConfig<any,any>
+  [key: string]: QueryParamConfig<any, any>
 } = {
-	topLocation: StringParam,
-	subLocation: StringParam,
+  topLocation: StringParam,
+  subLocation: StringParam,
 
-	riskProfile: StringParam,
-	interaction: StringParam,
-	personCount: NumberParam,
+  riskProfile: StringParam,
+  interaction: StringParam,
+  personCount: NumberParam,
 
-	setting: StringParam,
-	distance: StringParam,
-	duration: NumberParam,
-	theirMask: StringParam,
-	yourMask: StringParam,
-	voice: StringParam,
+  setting: StringParam,
+  distance: StringParam,
+  duration: NumberParam,
+  theirMask: StringParam,
+  yourMask: StringParam,
+  voice: StringParam,
 }
 
-export const filterParams = (
-	data: CalculatorData,
-	): QueryData => {
-	var filterData = { ...data }
-	var key: keyof CalculatorData
-	for (key in filterData) {
+export const filterParams = (data: CalculatorData): QueryData => {
+  const filterData = { ...data }
+  let key: keyof CalculatorData
+  for (key in filterData) {
     if (!(key in queryConfig) || data[key] === defaultValues[key]) {
-    	delete filterData[key]
+      delete filterData[key]
     }
   }
   return filterData
 }
 
 export const QueryParams = () => {
-	return useQueryParams(queryConfig)
+  return useQueryParams(queryConfig)
 }
-

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,9 +1,9 @@
+import { pickBy, isEmpty } from 'lodash'
+
 import { QueryParamConfigMap } from 'serialize-query-params'
 import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
 
-import { CalculatorData, defaultValues } from './calculate'
-
-export type QueryData = Partial<CalculatorData>
+import { CalculatorData, QueryData, defaultValues } from './calculate'
 
 const queryConfig: QueryParamConfigMap = {
   topLocation: StringParam,
@@ -30,6 +30,17 @@ export const filterParams = (data: CalculatorData): QueryData => {
     }
   }
   return filterData
+}
+
+// This method chooses between existing calulator data (either defaults or from a 
+// saved model) or the ones specified through query parameters.
+export const useParams = (queryData: QueryData, calcData: CalculatorData): CalculatorData => {
+  const queryDataFiltered = pickBy(queryData, v => v !== undefined)
+  if (isEmpty(queryDataFiltered)) {
+    return calcData
+  } else {
+    return { ...defaultValues, ...queryData }
+  }
 }
 
 export const QueryParams = (): ReturnType<typeof useQueryParams> => {

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,0 +1,42 @@
+import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
+import { QueryParamConfig } from 'serialize-query-params'
+
+import { CalculatorData, defaultValues } from './calculate'
+
+export type QueryData = Partial<CalculatorData>
+
+const queryConfig: {
+	[key: string]: QueryParamConfig<any,any>
+} = {
+	topLocation: StringParam,
+	subLocation: StringParam,
+
+	riskProfile: StringParam,
+	interaction: StringParam,
+	personCount: NumberParam,
+
+	setting: StringParam,
+	distance: StringParam,
+	duration: NumberParam,
+	theirMask: StringParam,
+	yourMask: StringParam,
+	voice: StringParam,
+}
+
+export const filterParams = (
+	data: CalculatorData,
+	): QueryData => {
+	var filterData = { ...data }
+	var key: keyof CalculatorData
+	for (key in filterData) {
+    if (!(key in queryConfig) || data[key] === defaultValues[key]) {
+    	delete filterData[key]
+    }
+  }
+  return filterData
+}
+
+export const QueryParams = () => {
+	return useQueryParams(queryConfig)
+}
+

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -1,5 +1,4 @@
-import { pickBy, isEmpty } from 'lodash'
-
+import { isEmpty, pickBy } from 'lodash'
 import { QueryParamConfigMap } from 'serialize-query-params'
 import { NumberParam, StringParam, useQueryParams } from 'use-query-params'
 
@@ -32,10 +31,13 @@ export const filterParams = (data: CalculatorData): QueryData => {
   return filterData
 }
 
-// This method chooses between existing calulator data (either defaults or from a 
+// This method chooses between existing calulator data (either defaults or from a
 // saved model) or the ones specified through query parameters.
-export const useParams = (queryData: QueryData, calcData: CalculatorData): CalculatorData => {
-  const queryDataFiltered = pickBy(queryData, v => v !== undefined)
+export const useParams = (
+  queryData: QueryData,
+  calcData: CalculatorData,
+): CalculatorData => {
+  const queryDataFiltered = pickBy(queryData, (v) => v !== undefined)
   if (isEmpty(queryDataFiltered)) {
     return calcData
   } else {

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -22,11 +22,14 @@ import {
   parsePopulation,
 } from 'data/calculate'
 import { saveCalculation } from 'data/localStorage'
+import { QueryParams, filterParams } from 'data/queryParams'
 
 const localStorage = window.localStorage
 const FORM_STATE_KEY = 'formData'
 
 export const Calculator = (): React.ReactElement => {
+  const [query, setQuery] = QueryParams()
+
   // Mount / unmount
   useEffect(() => {
     scrollListener()
@@ -42,10 +45,12 @@ export const Calculator = (): React.ReactElement => {
     localStorage.getItem(FORM_STATE_KEY) || 'null',
   )
 
+  const previousDataMerged = { ...previousData, ...query }
+
   const [showSaveForm, setShowSaveForm] = useState(false)
   const [saveName, setSaveName] = useState('')
   const [calculatorData, setCalculatorData] = useState<CalculatorData>(
-    migrateDataToCurrent(previousData),
+    migrateDataToCurrent(previousDataMerged),
   )
 
   const resetForm = () => {
@@ -77,6 +82,8 @@ export const Calculator = (): React.ReactElement => {
       }),
     )
 
+    setQuery(filterParams(calculatorData), 'replace')
+
     if (computedValue === null) {
       document.getElementById('points-row')?.classList.remove('has-points')
       return -1
@@ -85,7 +92,7 @@ export const Calculator = (): React.ReactElement => {
     document.getElementById('points-row')?.classList.add('has-points')
 
     return computedValue
-  }, [calculatorData])
+  }, [calculatorData, setQuery])
 
   const prevalenceIsFilled =
     calculatorData.topLocation !== '' ||

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -22,11 +22,7 @@ import {
   parsePopulation,
 } from 'data/calculate'
 import { saveCalculation } from 'data/localStorage'
-import {
-  QueryParams,
-  filterParams,
-  useParams
-} from 'data/queryParams'
+import { QueryParams, filterParams, useParams } from 'data/queryParams'
 
 const localStorage = window.localStorage
 const FORM_STATE_KEY = 'formData'
@@ -54,7 +50,7 @@ export const Calculator = (): React.ReactElement => {
   const [showSaveForm, setShowSaveForm] = useState(false)
   const [saveName, setSaveName] = useState('')
   const [calculatorData, setCalculatorData] = useState<CalculatorData>(
-    useParams(query, currentData)
+    useParams(query, currentData),
   )
 
   const resetForm = () => {

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Col, Row } from 'react-bootstrap'
+import { useQueryParams } from 'use-query-params'
 
 import {
   recordCalculatorChanged,
@@ -22,13 +23,17 @@ import {
   parsePopulation,
 } from 'data/calculate'
 import { saveCalculation } from 'data/localStorage'
-import { QueryParams, filterParams, useParams } from 'data/queryParams'
+import {
+  filterParams,
+  queryConfig,
+  useQueryDataIfPresent,
+} from 'data/queryParams'
 
 const localStorage = window.localStorage
 const FORM_STATE_KEY = 'formData'
 
 export const Calculator = (): React.ReactElement => {
-  const [query, setQuery] = QueryParams()
+  const [query, setQuery] = useQueryParams(queryConfig)
 
   // Mount / unmount
   useEffect(() => {
@@ -45,12 +50,12 @@ export const Calculator = (): React.ReactElement => {
     localStorage.getItem(FORM_STATE_KEY) || 'null',
   )
 
-  const currentData = migrateDataToCurrent(previousData)
+  const migratedPreviousData = migrateDataToCurrent(previousData)
 
   const [showSaveForm, setShowSaveForm] = useState(false)
   const [saveName, setSaveName] = useState('')
   const [calculatorData, setCalculatorData] = useState<CalculatorData>(
-    useParams(query, currentData),
+    useQueryDataIfPresent(query, migratedPreviousData),
   )
 
   const resetForm = () => {

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -22,7 +22,11 @@ import {
   parsePopulation,
 } from 'data/calculate'
 import { saveCalculation } from 'data/localStorage'
-import { QueryParams, filterParams } from 'data/queryParams'
+import {
+  QueryParams,
+  filterParams,
+  useParams
+} from 'data/queryParams'
 
 const localStorage = window.localStorage
 const FORM_STATE_KEY = 'formData'
@@ -45,12 +49,12 @@ export const Calculator = (): React.ReactElement => {
     localStorage.getItem(FORM_STATE_KEY) || 'null',
   )
 
-  const previousDataMerged = { ...previousData, ...query }
+  const currentData = migrateDataToCurrent(previousData)
 
   const [showSaveForm, setShowSaveForm] = useState(false)
   const [saveName, setSaveName] = useState('')
   const [calculatorData, setCalculatorData] = useState<CalculatorData>(
-    migrateDataToCurrent(previousDataMerged),
+    useParams(query, currentData)
   )
 
   const resetForm = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,6 +9673,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.13.5:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.5.tgz#99e95e2fb7021db90a6f373f990c0c814b3812d8"
+  integrity sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10657,6 +10666,11 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-query-params@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.2.3.tgz#0d6728c2378fa692233af80f4a72765db06f1069"
+  integrity sha512-pTssDTpnDR2p54q1/V1LpG/czg29iX9imxfKF1cupl30BWcRg8R8y3ddB4iHuhuVBO+HjSNj4+tAT1s075iimw==
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -10994,6 +11008,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11113,6 +11132,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -11902,6 +11926,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-query-params@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.1.8.tgz#61d5e2ad903da9ed807383e509b4b52343c886ad"
+  integrity sha512-tB9V4IEE1AbHHtbqxpIjajrDOJsnxS2+PrEfiI/zYatOgns3hkRqj+hrn7F0z5Vxf7z8k4ZV9CGanuk+tt8dEg==
+  dependencies:
+    serialize-query-params "^1.2.3"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9552,6 +9552,15 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.13.5:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.5.tgz#99e95e2fb7021db90a6f373f990c0c814b3812d8"
+  integrity sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10519,6 +10528,11 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-query-params@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-1.2.3.tgz#0d6728c2378fa692233af80f4a72765db06f1069"
+  integrity sha512-pTssDTpnDR2p54q1/V1LpG/czg29iX9imxfKF1cupl30BWcRg8R8y3ddB4iHuhuVBO+HjSNj4+tAT1s075iimw==
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -10838,6 +10852,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10957,6 +10976,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"
@@ -11741,6 +11765,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-query-params@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-1.1.8.tgz#61d5e2ad903da9ed807383e509b4b52343c886ad"
+  integrity sha512-tB9V4IEE1AbHHtbqxpIjajrDOJsnxS2+PrEfiI/zYatOgns3hkRqj+hrn7F0z5Vxf7z8k4ZV9CGanuk+tt8dEg==
+  dependencies:
+    serialize-query-params "^1.2.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
It's currently hard to share microcovid results for a specific set of assumptions. It would be really nice to, say, link to the assumptions for the presidential debate. This PR adds the use-query-param library and automatically updates query params based on changes to the form for easy sharing.

* Add user-query-params library, upgrade query-string
* Create a configuration for query parameters
* Update query parameters whenever calculator changes
* Adjust scroll behavior to avoid changing variables