### PR TITLE
Add "all on one page" to dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,9 @@ export const App = (): React.ReactElement => {
                     <NavDropdown.Item href="/paper">
                       Table of Contents
                     </NavDropdown.Item>
+                    <NavDropdown.Item href="/paper/all">
+                      All In One Page
+                    </NavDropdown.Item>
                     {Object.keys(pages).map((pageId, pageIndex) => (
                       <NavDropdown.Item
                         href={`/paper/${pageId}`}


### PR DESCRIPTION
Now that there's a dropdown, and people mostly won't use the TOC page, it'll be harder for people to discover that there's an "all in one page" option. Adding it to the menu.