### PR TITLE
Collapse location once set.

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -140,7 +140,7 @@ export const PrevalenceControls: React.FunctionComponent<{
   }, [])
 
   let subPrompt: string
-  if (data.topLocation.startsWith('US_')) {
+  if (isFilled(data.topLocation) && data.topLocation.startsWith('US_')) {
     if (Locations[data.topLocation].label === 'Louisiana') {
       subPrompt = 'Entire state, or select parish...'
     } else if (Locations[data.topLocation].label === 'Alaska') {
@@ -161,13 +161,16 @@ export const PrevalenceControls: React.FunctionComponent<{
   }
 
   const displayLocation = (): string => {
-    if (showPrevalance || !locationSet) {
+    if (showPrevalance) {
       return 'Step 1 - Choose a location'
     }
+    let display = 'Custom data'
     if (isFilled(data.subLocation)) {
-      return Locations[data.subLocation].label + ' - ' + adjustedPrevalance()
+      display = Locations[data.subLocation].label
+    } else if (isFilled(data.topLocation)) {
+      display = Locations[data.topLocation].label
     }
-    return Locations[data.topLocation].label + ' - ' + adjustedPrevalance()
+    return display + ' - ' + adjustedPrevalance()
   }
 
   return (

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Col, Row } from 'react-bootstrap'
+import { Col, Collapse, Row } from 'react-bootstrap'
 import { useQueryParams } from 'use-query-params'
 
 import {
@@ -34,6 +34,7 @@ const FORM_STATE_KEY = 'formData'
 
 export const Calculator = (): React.ReactElement => {
   const [query, setQuery] = useQueryParams(queryConfig)
+  const [showPrevalance, setShowPrevalance] = useState(true)
 
   // Mount / unmount
   useEffect(() => {
@@ -182,14 +183,18 @@ export const Calculator = (): React.ReactElement => {
       <Row id="calculator-fields">
         <Col md="12" lg="4">
           <Card id="location" title="Location & Prevalence">
-            <div className="subheading">
-              First, select a location to use in your calculations, or fill in
-              your own values based on data available in your area....
-            </div>
-
+            <Collapse in={showPrevalance}>
+              <div className="subheading">
+                First, select a location to use in your calculations, or fill in
+                your own values based on data available in your area....
+              </div>
+            </Collapse>
             <PrevalenceControls
               data={calculatorData}
               setter={setCalculatorData}
+              showPrevalance={showPrevalance}
+              onHeaderClicked={() => setShowPrevalance(!showPrevalance)}
+              onLocationSpecified={() => setShowPrevalance(false)}
             />
           </Card>
         </Col>

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -18,6 +18,7 @@ import { Card } from 'components/Card'
 import {
   CalculatorData,
   calculate,
+  calculateLocationPersonAverage,
   defaultValues,
   migrateDataToCurrent,
   parsePopulation,
@@ -193,7 +194,13 @@ export const Calculator = (): React.ReactElement => {
               data={calculatorData}
               setter={setCalculatorData}
               showPrevalance={showPrevalance}
-              onHeaderClicked={() => setShowPrevalance(!showPrevalance)}
+              onHeaderClicked={() => {
+                if (!calculateLocationPersonAverage(calculatorData)) {
+                  setShowPrevalance(true)
+                } else {
+                  setShowPrevalance(!showPrevalance)
+                }
+              }}
               onLocationSpecified={() => setShowPrevalance(false)}
             />
           </Card>


### PR DESCRIPTION
* Once location is fully specified, prevalance collapses.
  * This includes on reload
* If location is specified and the prevalance tab is open, data is shown as text, not uneditable fields.

After reset:
![image](https://user-images.githubusercontent.com/5877421/95279043-83438b80-0806-11eb-8cbf-e63db637af1a.png)

Set top location:
![image](https://user-images.githubusercontent.com/5877421/95279069-93f40180-0806-11eb-89fe-1b80636eb478.png)

Set sub location (or set top location for a region that doesn't have sublocations):
![image](https://user-images.githubusercontent.com/5877421/95279668-21842100-0808-11eb-923e-4935b986c49e.png)

You can click on the location to change it.