### PR TITLE
Add button to fix issue 60

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -70,10 +70,8 @@ const PrevalenceField: React.FunctionComponent<{
       onChange={(e) => {
         if (isNumber(max) || isNumber(min)) {
           let newValue = Number.parseFloat(e.target.value)
-          console.log(newValue)
           newValue = isNumber(max) && newValue > max ? max : newValue
           newValue = isNumber(min) && newValue < min ? min : newValue
-          console.log(newValue)
           setter(newValue.toString())
         } else {
           setter(e.target.value)

--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -108,7 +108,7 @@ export const PrevalenceResult = (props: {
   data: CalculatorData
 }): React.ReactElement => {
   return (
-    <Card className="prevelance-result">
+    <Card className="prevalence-result">
       <Card.Body>
         <div>
           <Trans>calculator.prevalence.reported_prevalence</Trans>:{' '}
@@ -251,7 +251,7 @@ export const PrevalenceControls: React.FunctionComponent<{
       )}
 
       <ControlledExpandable
-        id="prevelance-details"
+        id="prevalence-details"
         header={t('calculator.prevalence.details_header')}
         headerClassName={isManualEntryCurrently ? 'd-none' : ''}
         open={detailsOpen}

--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -148,10 +148,6 @@ export const PrevalenceControls: React.FunctionComponent<{
     }
   }
 
-  const handleEnterDataButtonOnClick = () => {
-    setLocationData(TOP_LOCATION_MANUAL_ENTRY, '')
-  }
-
   const setLocationData = (topLocation: string, subLocation: string) => {
     if (isManualEntry(topLocation)) {
       setDetailsOpen(true)
@@ -162,6 +158,14 @@ export const PrevalenceControls: React.FunctionComponent<{
       topLocation,
       subLocation,
     })
+  }
+
+  const handleEnterDataButtonOnClick = () => {
+    setLocationData(TOP_LOCATION_MANUAL_ENTRY, '')
+  }
+
+  const handleSelectLocationButtonOnClick = () => {
+    setLocationData('', '')
   }
 
   // If a stored location exists, load latest data for that location.
@@ -189,6 +193,11 @@ export const PrevalenceControls: React.FunctionComponent<{
     Locations[data.topLocation].subdivisions.length > 1
 
   const locationSet = isTopLocation(data.topLocation)
+
+  const showEnterDataButton =
+    locationSet ||
+    !isFilled(data.topLocation) ||
+    data.topLocation !== TOP_LOCATION_MANUAL_ENTRY
 
   const [detailsOpen, setDetailsOpen] = useState(
     false || isManualEntry(data.topLocation),
@@ -226,15 +235,6 @@ export const PrevalenceControls: React.FunctionComponent<{
             </optgroup>
           ))}
         </select>
-        {!locationSet ? null : (
-          <button
-            id="enterData"
-            className="btn btn-secondary"
-            onClick={handleEnterDataButtonOnClick}
-          >
-            {t('calculator.select_location_enter_manually')}
-          </button>
-        )}
       </div>
       {!showSubLocation ? null : (
         <div className="form-group">
@@ -260,7 +260,23 @@ export const PrevalenceControls: React.FunctionComponent<{
           </select>
         </div>
       )}
-
+      {!showEnterDataButton ? (
+        <button
+          id="switchBetweenManualDataAndLocationSelection"
+          className="btn btn-secondary"
+          onClick={handleSelectLocationButtonOnClick}
+        >
+          {t('calculator.switch_button.select_location')}
+        </button>
+      ) : (
+        <button
+          id="switchBetweenManualDataAndLocationSelection"
+          className="btn btn-secondary"
+          onClick={handleEnterDataButtonOnClick}
+        >
+          {t('calculator.switch_button.enter_data_manually')}
+        </button>
+      )}
       <ControlledExpandable
         id="prevalence-details"
         header={t('calculator.prevalence.details_header')}

--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -148,6 +148,10 @@ export const PrevalenceControls: React.FunctionComponent<{
     }
   }
 
+  const handleEnterDataButtonOnClick = () => {
+    setLocationData(TOP_LOCATION_MANUAL_ENTRY, '')
+  }
+
   const setLocationData = (topLocation: string, subLocation: string) => {
     if (isManualEntry(topLocation)) {
       setDetailsOpen(true)
@@ -222,6 +226,15 @@ export const PrevalenceControls: React.FunctionComponent<{
             </optgroup>
           ))}
         </select>
+        {!locationSet ? null : (
+          <button
+            id="enterData"
+            className="btn btn-secondary"
+            onClick={handleEnterDataButtonOnClick}
+          >
+            {t('calculator.select_location_enter_manually')}
+          </button>
+        )}
       </div>
       {!showSubLocation ? null : (
         <div className="form-group">

--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -194,23 +194,18 @@ export const PrevalenceControls: React.FunctionComponent<{
 
   const locationSet = isTopLocation(data.topLocation)
 
-  const showEnterDataButton =
-    locationSet ||
-    !isFilled(data.topLocation) ||
-    data.topLocation !== TOP_LOCATION_MANUAL_ENTRY
+  const isManualEntryCurrently = isManualEntry(data.topLocation)
 
   const [detailsOpen, setDetailsOpen] = useState(
-    false || isManualEntry(data.topLocation),
+    false || isManualEntryCurrently,
   )
-
-  const isManualEntryCurrently = isManualEntry(data.topLocation)
 
   return (
     <React.Fragment>
       <header id="location">
         <Trans>calculator.location_selector_header</Trans>
       </header>
-      <div className="form-group">
+      <div className="form-group" hidden={isManualEntryCurrently}>
         <select
           className="form-control form-control-lg"
           value={data.topLocation}
@@ -221,9 +216,6 @@ export const PrevalenceControls: React.FunctionComponent<{
         >
           <option value="">
             {t('calculator.select_location_placeholder')}
-          </option>
-          <option value={TOP_LOCATION_MANUAL_ENTRY}>
-            {t('calculator.select_location_enter_manually')}
           </option>
           {Object.keys(locationGroups).map((groupName, groupInd) => (
             <optgroup key={groupInd} label={groupName}>
@@ -260,7 +252,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           </select>
         </div>
       )}
-      {!showEnterDataButton ? (
+      {isManualEntryCurrently ? (
         <button
           id="switchBetweenManualDataAndLocationSelection"
           className="btn btn-secondary"
@@ -310,7 +302,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           <div>{t('calculator.prevalence.cases_stable_or_decreasing')}</div>
         ) : (
           <PrevalenceField
-            id="precent-increase"
+            id="percent-increase"
             label={t('calculator.prevalence.percent_increase_in_cases')}
             value={data.casesIncreasingPercentage}
             unit="%"

--- a/src/components/calculator/styles/PrevalenceControls.scss
+++ b/src/components/calculator/styles/PrevalenceControls.scss
@@ -1,7 +1,7 @@
 @import '~styles/variables.scss';
 
-#prevelance-details {
-  .prevelance-result.card {
+#prevalence-details {
+  .prevalence-result.card {
     height: auto;
     border: 1px solid $secondary;
     margin: 0.5rem;

--- a/src/components/calculator/styles/PrevalenceControls.scss
+++ b/src/components/calculator/styles/PrevalenceControls.scss
@@ -10,3 +10,8 @@
     }
   }
 }
+
+button#enterData {
+  margin-top: 15px;
+}
+

--- a/src/components/calculator/styles/PrevalenceControls.scss
+++ b/src/components/calculator/styles/PrevalenceControls.scss
@@ -11,7 +11,7 @@
   }
 }
 
-button#enterData {
-  margin-top: 15px;
+button#switchBetweenManualDataAndLocationSelection {
+  margin-bottom: 15px;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,10 +111,9 @@
     "location_subprompt_US": "Entire state, or select county...",
     "location_selector_header": "Step 1: Location Risk",
     "select_location_placeholder": "Select location...",
-    "select_location_enter_manually": "Enter data manually...",
     "switch_button": {
-      "select_location": "Or select location",
-      "enter_data_manually": "Or enter data manually"
+      "select_location": "Switch to pre-populated location data",
+      "enter_data_manually": "Switch to manual data entry mode"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), and <7>Our World in Data</7> (international positive test rates).",
     "select_scenario": "Optional: Start with a predefined common activity",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -109,7 +109,7 @@
     "location_subprompt_US-LA": "Entire state, or select parish...",
     "location_subprompt_US-AK": "Entire state, or select borough...",
     "location_subprompt_US": "Entire state, or select county...",
-    "location_selector_header": "Step 1: Enter your location",
+    "location_selector_header": "Step 1: Location Risk",
     "select_location_placeholder": "Select location...",
     "select_location_enter_manually": "Enter data manually...",
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), and <7>Our World in Data</7> (international positive test rates).",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,6 +112,10 @@
     "location_selector_header": "Step 1: Location Risk",
     "select_location_placeholder": "Select location...",
     "select_location_enter_manually": "Enter data manually...",
+    "switch_button": {
+      "select_location": "Or select location",
+      "enter_data_manually": "Or enter data manually"
+    },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), and <7>Our World in Data</7> (international positive test rates).",
     "select_scenario": "Optional: Start with a predefined common activity",
     "baseline_risk": "baseline risk",


### PR DESCRIPTION
Fixes https://github.com/microcovid/microcovid/issues/60

## Description

(Please note that I am a Ruby developer, not a React developer, so there may be whoopsies.)

This displays a `or enter data` button if no top location has been set. The button selects `Select a location or enter data...` on the top location drop-down. The button does not exist when `Select a location or enter data...` is selected.

'Step 1 - Choose a location' has been edited to say 'Step 1 - Location Risk' (to match the Person Risk and Activity Risk sections, and to avoid implying that the only method of getting the location risk is by choosing a location from the drop-down.)

## Screenshots

<img width="397" alt="Screenshot 2020-10-09 at 14 53 27" src="https://user-images.githubusercontent.com/60350599/95591722-98efc580-0a3f-11eb-9f42-37eb06419f08.png">
<img width="397" alt="Screenshot 2020-10-09 at 14 53 36" src="https://user-images.githubusercontent.com/60350599/95591723-99885c00-0a3f-11eb-8b3e-60cbba5b5289.png">
