### PR TITLE
Allow the calculator to display numbers closer to 1e6uCoV

### DIFF
--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 
 import { GenericSelectControl } from './SelectControl'
 import Card from 'components/Card'
-import { ERROR_FACTOR, MAX_POINTS } from 'data/calculate'
+import { MAX_POINTS } from 'data/calculate'
 import {
   fixedPointPrecision,
   fixedPointPrecisionPercent,
@@ -133,16 +133,17 @@ const budgetConsumption = (
 export function PointsDisplay(props: {
   points: number
   repeatedEvent: boolean
+  upperBound: number
+  lowerBound: number
 }): React.ReactElement {
   return (
     <div className="top-half-card">
       <strong>Results:</strong>
       {showPoints(props.points) ? (
         <h1>
-          ~{displayPoints(props.points)} microCOVIDs (
-          {displayPoints(props.points / ERROR_FACTOR)} to{' '}
-          {displayPoints(props.points * ERROR_FACTOR)})
-          {props.repeatedEvent ? ' per week' : ' each time'}
+          {displayPoints(props.points)} microCOVIDs (
+          {displayPoints(props.lowerBound)} to {displayPoints(props.upperBound)}
+          ){props.repeatedEvent ? ' per week' : ' each time'}
         </h1>
       ) : (
         <h1>fill in calculator to see</h1>

--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -26,10 +26,6 @@ function tooManyPoints(points: number): boolean {
   return points >= MAX_POINTS
 }
 
-function maybeGreater(points: number): string {
-  return tooManyPoints(points) ? '>' : ''
-}
-
 export function ExplanationCard(props: {
   points: number
   repeatedEvent: boolean
@@ -78,8 +74,7 @@ export function ExplanationCard(props: {
       </p>
       <h2>What does this mean numerically?</h2>
       <p>
-        This is a roughly {maybeGreater(points)}
-        {displayPoints(points)}-in-a-million ({maybeGreater(points)}
+        This is a roughly ~{displayPoints(points)}-in-a-million (
         {displayPercent(points)}){props.repeatedEvent ? ' per week ' : ' '}
         chance of getting COVID from this activity with these people.
       </p>
@@ -144,11 +139,8 @@ export function PointsDisplay(props: {
       <strong>Results:</strong>
       {showPoints(props.points) ? (
         <h1>
-          {tooManyPoints(props.points) ? '>' : '~'}
-          {displayPoints(props.points)} microCOVIDs (
-          {maybeGreater(props.points)}
+          ~{displayPoints(props.points)} microCOVIDs (
           {displayPoints(props.points / ERROR_FACTOR)} to{' '}
-          {maybeGreater(props.points)}
           {displayPoints(props.points * ERROR_FACTOR)})
           {props.repeatedEvent ? ' per week' : ' each time'}
         </h1>

--- a/src/data/FormatPrecision.ts
+++ b/src/data/FormatPrecision.ts
@@ -1,5 +1,21 @@
 const SIGFIGS = 1
 
+// Internal helper for rounding a number without inserting commas.
+function fixedPointNumber(val: number): string {
+  const orderOfMagnitude = Math.floor(Math.log10(val))
+  let sigfigs = SIGFIGS
+  if (val > 9e5 && val < 1e6) {
+    // Try to avoid rounding to 1 million uCoV; show up to 6 sigfigs to accomplish this.
+    sigfigs = Math.min(6, 6 - Math.floor(Math.log10(1e6 - val)))
+  }
+  const orderOfMangitudeToDisplay = orderOfMagnitude - sigfigs + 1
+  const decimalsToDisplay =
+    orderOfMangitudeToDisplay > 0 ? 0 : -orderOfMangitudeToDisplay
+  const roundedValue = Number.parseFloat(val.toPrecision(sigfigs))
+  const withoutCommas = roundedValue.toFixed(decimalsToDisplay)
+  return withoutCommas
+}
+
 /**
  * Format points for display - fixed point with a set precision.
  * This is necessary because float.toPrecision will use exponential notation for large or small numbers.
@@ -8,12 +24,7 @@ export function fixedPointPrecision(val: number | null): string {
   if (!val) {
     return '0'
   }
-  const orderOfMagnitude = Math.floor(Math.log10(val))
-  const orderOfMangitudeToDisplay = orderOfMagnitude - SIGFIGS + 1
-  const decimalsToDisplay =
-    orderOfMangitudeToDisplay > 0 ? 0 : -orderOfMangitudeToDisplay
-  const roundedValue = Number.parseFloat(val.toPrecision(SIGFIGS))
-  const withoutCommas = roundedValue.toFixed(decimalsToDisplay)
+  const withoutCommas = fixedPointNumber(val)
   if (withoutCommas.indexOf('.') !== -1 || withoutCommas.length <= 3) {
     return withoutCommas
   }
@@ -40,5 +51,6 @@ export function fixedPointPrecisionPercent(val: number | null): string {
   if (!val) {
     return '0%'
   }
-  return fixedPointPrecision(val * 100) + '%'
+  console.log(fixedPointNumber(999620))
+  return Number.parseFloat(fixedPointNumber(val * 1e6)) * 1e-4 + '%'
 }

--- a/src/data/FormatPrecision.ts
+++ b/src/data/FormatPrecision.ts
@@ -51,6 +51,5 @@ export function fixedPointPrecisionPercent(val: number | null): string {
   if (!val) {
     return '0%'
   }
-  console.log(fixedPointNumber(999620))
   return Number.parseFloat(fixedPointNumber(val * 1e6)) * 1e-4 + '%'
 }

--- a/src/data/__tests__/FormatPrecision.test.ts
+++ b/src/data/__tests__/FormatPrecision.test.ts
@@ -1,0 +1,38 @@
+import {
+  fixedPointPrecision,
+  fixedPointPrecisionPercent,
+} from 'data/FormatPrecision'
+
+describe('fixedPointPrecision', () => {
+  it('rounds numbers greater than 1', () => {
+    expect(fixedPointPrecision(11)).toEqual('10')
+    expect(fixedPointPrecision(16)).toEqual('20')
+    expect(fixedPointPrecision(230)).toEqual('200')
+  })
+
+  it('rounds numbers less than 1', () => {
+    expect(fixedPointPrecision(0.11)).toEqual('0.1')
+    expect(fixedPointPrecision(0.046)).toEqual('0.05')
+  })
+
+  it('adds commas', () => {
+    expect(fixedPointPrecision(10000)).toEqual('10,000')
+    expect(fixedPointPrecision(1e6)).toEqual('1,000,000')
+  })
+  it('shows precision for numbers close to 1e6', () => {
+    expect(fixedPointPrecision(996700)).toEqual('997,000')
+    expect(fixedPointPrecision(999920)).toEqual('999,920')
+  })
+})
+
+describe('fixedPointPrecisionPercent', () => {
+  it('rounds numbers and formats as percent', () => {
+    expect(fixedPointPrecisionPercent(1)).toEqual('100%')
+    expect(fixedPointPrecisionPercent(0.16)).toEqual('20%')
+    expect(fixedPointPrecisionPercent(0.0022)).toEqual('0.2%')
+  })
+
+  it('shows precision for percentages close to 1', () => {
+    expect(fixedPointPrecisionPercent(0.9992)).toEqual('99.92%')
+  })
+})

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -70,12 +70,18 @@ export const Calculator = (): React.ReactElement => {
     recordSavedCustom(points)
   }
 
-  const points = useMemo(() => {
+  const { points, lowerBound, upperBound } = useMemo(() => {
     // Risk calculation
-    const computedValue = calculate(calculatorData)
+    const result = calculate(calculatorData)
+    if (result === null) {
+      document.getElementById('points-row')?.classList.remove('has-points')
+      return { points: -1, lowerBound: -1, upperBound: -1 }
+    }
 
-    if (computedValue) {
-      recordCalculatorChanged(computedValue)
+    const { expectedValue, lowerBound, upperBound } = result
+
+    if (expectedValue) {
+      recordCalculatorChanged(expectedValue)
     }
 
     // Store data for refresh
@@ -89,14 +95,9 @@ export const Calculator = (): React.ReactElement => {
 
     setQuery(filterParams(calculatorData), 'replace')
 
-    if (computedValue === null) {
-      document.getElementById('points-row')?.classList.remove('has-points')
-      return -1
-    }
-
     document.getElementById('points-row')?.classList.add('has-points')
 
-    return computedValue
+    return { points: expectedValue, lowerBound, upperBound }
   }, [calculatorData, setQuery])
 
   const prevalenceIsFilled =
@@ -235,7 +236,12 @@ export const Calculator = (): React.ReactElement => {
       </Row>
       <Row className="sticky" id="points-row">
         <Col lg={{ span: 8, offset: 4 }}>
-          <PointsDisplay points={points} repeatedEvent={repeatedEvent} />
+          <PointsDisplay
+            points={points}
+            lowerBound={lowerBound}
+            upperBound={upperBound}
+            repeatedEvent={repeatedEvent}
+          />
         </Col>
       </Row>
       <Row className="explanation" id="explanation-row">


### PR DESCRIPTION
* Compute risk as 1 - (1 - risk_each) ^ N if we would otherwise show 10%
* Note that this allows us to show "1 housemate with covid = 30%"
* Augment display functions to show more sigfigs when close to 1e6

Fixes: 331