### PR TITLE
UX Redesign: Fix styling bug underneath calculator accent headers

### DIFF
--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -122,6 +122,7 @@ h1,h2,h3,h4,h5,h6 {
 .accent span {
   display: inline-block;
   position: relative;  
+  padding-bottom: .3em;
 }
 .accent span:after {
   content: "";


### PR DESCRIPTION
Text under "nearby people" was cut off without some padding.