### PR TITLE
Fix spelling error and inconsistent capitalization

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -202,8 +202,7 @@ export const RiskProfileEnum = {
 }
 
 RiskProfile[RiskProfileEnum.ONE_PERCENT] = {
-  label:
-    'Uses microCOVID to maintain a risk of 1%/year (200 microCOVIDs/week)',
+  label: 'Uses microCOVID to maintain a risk of 1%/year (200 microCOVIDs/week)',
   multiplier: NaN,
 }
 

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -202,12 +202,14 @@ export const RiskProfileEnum = {
 }
 
 RiskProfile[RiskProfileEnum.ONE_PERCENT] = {
-  label: 'Uses microCOVID to maintain a risk of 1%/year (200 microCOVIDs/week)',
+  label:
+    'Uses microCOVID to maintain a risk of 1%/year (200 microCOVIDs/week)',
   multiplier: NaN,
 }
 
 RiskProfile[RiskProfileEnum.DECI_PERCENT] = {
-  label: 'Uses microCOVID to maintain a risk of 0.1%/year (20 microCOVIDs/week)',
+  label:
+    'Uses microCOVID to maintain a risk of 0.1%/year (20 microCOVIDs/week)',
   multiplier: NaN,
 }
 

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -202,12 +202,12 @@ export const RiskProfileEnum = {
 }
 
 RiskProfile[RiskProfileEnum.ONE_PERCENT] = {
-  label: 'Uses microcvoid to maintain a risk of 1%/year (200 microcovid/week)',
+  label: 'Uses microCOVID to maintain a risk of 1%/year (200 microCOVIDs/week)',
   multiplier: NaN,
 }
 
 RiskProfile[RiskProfileEnum.DECI_PERCENT] = {
-  label: 'Uses microcvoid to maintain a risk of 0.1%/year (20 microcovid/week)',
+  label: 'Uses microCOVID to maintain a risk of 0.1%/year (20 microCOVIDs/week)',
   multiplier: NaN,
 }
 


### PR DESCRIPTION
This leaves one inconsistency with whether you write `microCOVIDs/week` or `microCOVIDs per week`.