### PR TITLE
Fixing the note around mask usage and eating (#457)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,7 +14,7 @@
   "calculator.precautions.your_mask_note": "If you’re eating or drinking, select “no mask”",
   "calculator.precautions.their_mask_header": "Their mask",
   "calculator.precautions.their_mask_question": "What mask are THEY wearing?",
-  "calculator.precautions.their_mask_note": "If you’re eating or drinking, select “no mask”",
+  "calculator.precautions.their_mask_note": "If they’re eating or drinking, select “no mask”",
   "calculator.precautions.volume_header": "Volume",
   "calculator.precautions.volume_question": "How much is everyone talking?",
   "calculator.explanationcard.person": "person",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -14,7 +14,7 @@
   "calculator.precautions.your_mask_note": "Ha eszel vagy iszol, vedd úgy, hogy nincs rajtad maszk",
   "calculator.precautions.their_mask_header": "Az ő maszkjuk",
   "calculator.precautions.their_mask_question": "Milyen maszk van a többieken?",
-  "calculator.precautions.their_mask_note": "Ha eszel vagy iszol, vedd úgy, hogy nincs rajtuk maszk",
+  "calculator.precautions.their_mask_note": "Ha esznek vagy isznak, vedd úgy, hogy nincs rajtuk maszk",
   "calculator.precautions.volume_header": "A beszélgetés hangereje",
   "calculator.precautions.volume_question": "Milyen hangosan beszélgettek?",
   "calculator.explanationcard.person": "ember",


### PR DESCRIPTION
This closes #457 and now merges cleanly onto the new main branch.

Both notes refer to your own mask, but others eating and drinking should only affect their own mask usage, not yours.