### PR TITLE
[calculator] fix copy share button spacing

### DIFF
--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -81,6 +81,7 @@ export const Calculator = (): React.ReactElement => {
       filterParams(calculatorData),
     )
     const location = window.location
+    // eslint-disable-next-line prettier/prettier
     const link = `${location.protocol}//${location.host}${location.pathname}?${stringify(encodedQuery)}`
     return link
   }

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -81,8 +81,9 @@ export const Calculator = (): React.ReactElement => {
       filterParams(calculatorData),
     )
     const location = window.location
-    // eslint-disable-next-line prettier/prettier
-    const link = `${location.protocol}//${location.host}${location.pathname}?${stringify(encodedQuery)}`
+
+    let link = `${location.protocol}//${location.host}${location.pathname}`
+    link += `${link}?${stringify(encodedQuery)}`
     return link
   }
 

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -81,8 +81,7 @@ export const Calculator = (): React.ReactElement => {
       filterParams(calculatorData),
     )
     const location = window.location
-    const link = `${location.protocol}//${location.host}${location.pathname}
-    ?${stringify(encodedQuery)}`
+    const link = `${location.protocol}//${location.host}${location.pathname}?${stringify(encodedQuery)}`
     return link
   }
 


### PR DESCRIPTION
Fixes the URL copied, it had a new line in the middle.

Expected:
```
https://www.microcovid.org/distance=sixFt&duration=180&interaction=oneTime&personCount=6&riskProfile=average&setting=outdoor&subLocation=US_08117&theirMask=basic&topLocation=US_08&voice=normal&yourMask=filtered
```

Observed:
```
https://www.microcovid.org/
    ?distance=sixFt&duration=180&interaction=oneTime&personCount=6&riskProfile=average&setting=outdoor&subLocation=US_08117&theirMask=basic&topLocation=US_08&voice=normal&yourMask=filtered
```


