### PR TITLE
Add discreet string types to CalculatorData interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .env.production.local
 .venv
 .prevalence_data.json
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -1,8 +1,14 @@
 import {
   CalculatorData,
+  DistanceType,
+  InteractionType,
+  MaskType,
+  RiskProfileType,
+  SettingType,
+  VoiceType,
   calculate,
   calculateLocationPersonAverage,
-  defaultValues, SettingType, DistanceType, MaskType, VoiceType, RiskProfileType, InteractionType,
+  defaultValues,
 } from 'data/calculate'
 import { BUDGET_ONE_PERCENT, RiskProfile, RiskProfileEnum } from 'data/data'
 import { prepopulated } from 'data/prepopulated'

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -2,7 +2,7 @@ import {
   CalculatorData,
   calculate,
   calculateLocationPersonAverage,
-  defaultValues,
+  defaultValues, SettingType, DistanceType, MaskType, VoiceType, RiskProfileType, InteractionType,
 } from 'data/calculate'
 import { BUDGET_ONE_PERCENT, RiskProfile, RiskProfileEnum } from 'data/data'
 import { prepopulated } from 'data/prepopulated'
@@ -31,12 +31,12 @@ describe('calculate', () => {
 
   // Variables that should be ignored for repeated/partner interactions.
   const repeatedDontCare = {
-    setting: 'indoor',
-    distance: 'sixFt',
+    setting: 'indoor' as SettingType,
+    distance: 'sixFt' as DistanceType,
     duration: 60,
-    theirMask: 'none',
-    yourMask: 'none',
-    voice: 'normal',
+    theirMask: 'none' as MaskType,
+    yourMask: 'none' as MaskType,
+    voice: 'normal' as VoiceType,
   }
 
   const expectedPrevalance = 0.006
@@ -92,16 +92,16 @@ describe('calculate', () => {
   it('should produce a self-consistent living alone risk profile', () => {
     const data: CalculatorData = {
       ...baseTestData,
-      riskProfile: 'average',
-      interaction: 'oneTime',
+      riskProfile: 'average' as RiskProfileType,
+      interaction: 'oneTime' as InteractionType,
       personCount: 10,
 
-      setting: 'indoor',
-      distance: 'sixFt',
+      setting: 'indoor' as SettingType,
+      distance: 'sixFt' as DistanceType,
       duration: 60,
-      theirMask: 'basic',
-      yourMask: 'filtered',
-      voice: 'silent',
+      theirMask: 'basic' as MaskType,
+      yourMask: 'filtered' as MaskType,
+      voice: 'silent' as VoiceType,
     }
 
     expect(calcValue(data)).toBeCloseTo(
@@ -112,16 +112,16 @@ describe('calculate', () => {
   it('should handle large risks', () => {
     const data: CalculatorData = {
       ...baseTestData,
-      riskProfile: 'hasCovid',
-      interaction: 'repeated',
+      riskProfile: 'hasCovid' as RiskProfileType,
+      interaction: 'repeated' as InteractionType,
       personCount: 1,
 
-      setting: 'indoor',
-      distance: 'sixFt',
+      setting: 'indoor' as SettingType,
+      distance: 'sixFt' as DistanceType,
       duration: 60,
-      theirMask: 'basic',
-      yourMask: 'filtered',
-      voice: 'silent',
+      theirMask: 'basic' as MaskType,
+      yourMask: 'filtered' as MaskType,
+      voice: 'silent' as VoiceType,
     }
 
     const oneTime = calculate(data)
@@ -146,8 +146,8 @@ describe('calculate', () => {
       const data: CalculatorData = {
         ...baseTestData,
         ...repeatedDontCare,
-        riskProfile: profile,
-        interaction: 'repeated',
+        riskProfile: profile as RiskProfileType,
+        interaction: 'repeated' as InteractionType,
         personCount: 1,
       }
 
@@ -193,8 +193,8 @@ describe('calculate', () => {
   describe('Interaction: housemate', () => {
     const base = {
       ...baseTestData,
-      riskProfile: 'average',
-      interaction: 'repeated',
+      riskProfile: 'average' as RiskProfileType,
+      interaction: 'repeated' as InteractionType,
       personCount: 1,
     }
     const housemate: CalculatorData = {

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -40,7 +40,13 @@ export type SettingType =
   | 'carWindowsDown'
   | 'partiallyEnclosed'
   | ''
-export type DistanceType = 'intimate' | 'close' | 'normal' | 'sixFt' | 'tenFt' | ''
+export type DistanceType =
+  | 'intimate'
+  | 'close'
+  | 'normal'
+  | 'sixFt'
+  | 'tenFt'
+  | ''
 export type MaskType = 'none' | 'basic' | 'filtered' | 'n95' | ''
 export type VoiceType = 'silent' | 'normal' | 'loud' | ''
 

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -12,7 +12,7 @@ import {
   intimateDurationFloor,
 } from 'data/data'
 
-type RiskProfileType =
+export type RiskProfileType =
   | 'average'
   | 'frontline'
   | 'nonFrontline'
@@ -31,7 +31,7 @@ type RiskProfileType =
   | 'hasCovid'
   | ''
 export type InteractionType = 'oneTime' | 'repeated' | 'partner' | ''
-type SettingType =
+export type SettingType =
   | 'indoor'
   | 'outdoor'
   | 'filtered'
@@ -40,9 +40,9 @@ type SettingType =
   | 'carWindowsDown'
   | 'partiallyEnclosed'
   | ''
-type DistanceType = 'intimate' | 'close' | 'normal' | 'sixFt' | 'tenFt' | ''
-type MaskType = 'none' | 'basic' | 'filtered' | 'n95' | ''
-type VoiceType = 'silent' | 'normal' | 'loud' | ''
+export type DistanceType = 'intimate' | 'close' | 'normal' | 'sixFt' | 'tenFt' | ''
+export type MaskType = 'none' | 'basic' | 'filtered' | 'n95' | ''
+export type VoiceType = 'silent' | 'normal' | 'loud' | ''
 
 export interface CalculatorData {
   // Persistence

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -12,33 +12,65 @@ import {
   intimateDurationFloor,
 } from 'data/data'
 
+type RiskProfileType =
+  | 'average'
+  | 'frontline'
+  | 'nonFrontline'
+  | 'livingAlone'
+  | 'livingWithPartner'
+  | 'closedPod4'
+  | 'closedPod10'
+  | 'closedPod20'
+  | 'contact1'
+  | 'contact4'
+  | 'contact10'
+  | 'contactWorks'
+  | 'bars'
+  | 'onePercent'
+  | 'deciPercent'
+  | 'hasCovid'
+  | ''
+export type InteractionType = 'oneTime' | 'repeated' | 'partner' | ''
+type SettingType =
+  | 'indoor'
+  | 'outdoor'
+  | 'filtered'
+  | 'transit'
+  | 'plane'
+  | 'carWindowsDown'
+  | 'partiallyEnclosed'
+  | ''
+type DistanceType = 'intimate' | 'close' | 'normal' | 'sixFt' | 'tenFt' | ''
+type MaskType = 'none' | 'basic' | 'filtered' | 'n95' | ''
+type VoiceType = 'silent' | 'normal' | 'loud' | ''
+
 export interface CalculatorData {
   // Persistence
-  persistedAt?: number
+  persistedAt?: number // epoch ms, last time calc data persisted in localstorage
 
-  // Budget (in microCOVIDs/year)
-  riskBudget: number
+  // Budget
+  riskBudget: number // microCOVIDs/year
 
   // Prevalence
-  topLocation: string
-  subLocation: string
+  topLocation: string // e.g. 'California'
+  subLocation: string // e.g. 'San Francisco'
   population: string
   casesPastWeek: number
-  casesIncreasingPercentage: number
-  positiveCasePercentage: number | null
+  casesIncreasingPercentage: number // e.g. 30.3
+  positiveCasePercentage: number | null // e.g. 3.1
 
   // Person risk
-  riskProfile: string
-  interaction: string
+  riskProfile: RiskProfileType
+  interaction: InteractionType
   personCount: number
 
   // Activity risk
-  setting: string
-  distance: string
+  setting: SettingType
+  distance: DistanceType
   duration: number
-  theirMask: string
-  yourMask: string
-  voice: string
+  theirMask: MaskType
+  yourMask: MaskType
+  voice: VoiceType
 }
 
 export const defaultValues: CalculatorData = {

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -20,6 +20,7 @@ import { GenericSelectControl } from 'components/calculator/SelectControl'
 import { Card } from 'components/Card'
 import {
   CalculatorData,
+  InteractionType,
   calculate,
   defaultValues,
   migrateDataToCurrent,
@@ -207,7 +208,7 @@ export const Calculator = (): React.ReactElement => {
                     setter={(value) =>
                       setCalculatorData({
                         ...calculatorData,
-                        interaction: value,
+                        interaction: value as InteractionType,
                         personCount:
                           value === 'partner' ? 1 : calculatorData.personCount,
                       })


### PR DESCRIPTION
Hey all! Awesome site.

I cloned the project locally and was looking to run the `calculate` function from my terminal. I had to do a bit of searching around to see the options available for certain fields e.g. `riskProfile`. I copied the available options over from `data.ts` to make discreet string types for these fields.

May not be following DRY best-practices by doing this - very reasonable to not merge this small change in the name of maintainability. Just wanted to throw a small PR at a project I think is great! Best,

Leo