### PR TITLE
Break down RiskProfile calculation

### DIFF
--- a/src/components/calculator/ExplanationCard/ExplanationCard.tsx
+++ b/src/components/calculator/ExplanationCard/ExplanationCard.tsx
@@ -135,7 +135,7 @@ export default function ExplanationCard(props: {
               <br />
               <Trans values={{ person_risk: personRiskEachFormatted }}>
                 {props.data.interaction !== 'oneTime' &&
-                RiskProfile[props.data.riskProfile].housemateMultiplier
+                RiskProfile[props.data.riskProfile].numHousemates > 1
                   ? 'calculator.explanationcard.details_person_risk_explanation_housemate'
                   : 'calculator.explanationcard.details_person_risk_explanation'}
               </Trans>

--- a/src/components/calculator/ExplanationCard/ExplanationCard.tsx
+++ b/src/components/calculator/ExplanationCard/ExplanationCard.tsx
@@ -135,7 +135,7 @@ export default function ExplanationCard(props: {
               <br />
               <Trans values={{ person_risk: personRiskEachFormatted }}>
                 {props.data.interaction !== 'oneTime' &&
-                RiskProfile[props.data.riskProfile].numHousemates > 1
+                RiskProfile[props.data.riskProfile].numHousemates >= 1
                   ? 'calculator.explanationcard.details_person_risk_explanation_housemate'
                   : 'calculator.explanationcard.details_person_risk_explanation'}
               </Trans>

--- a/src/components/calculator/SelectControl.tsx
+++ b/src/components/calculator/SelectControl.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from 'react-i18next'
 import ControlLabel from './ControlLabel'
 import IosOptgroup from 'components/IosOptgroup'
 import { CalculatorData } from 'data/calculate'
-import { FormValue } from 'data/data'
+import { BaseFormValue } from 'data/data'
 
 export const GenericSelectControl: React.FunctionComponent<{
   id: string
   setter: (value: string) => void
-  source: { [key: string]: FormValue }
+  source: { [key: string]: BaseFormValue }
   value: string | number | Date
   label?: string
   header?: string
@@ -21,7 +21,7 @@ export const GenericSelectControl: React.FunctionComponent<{
   className?: string
 }> = (props) => {
   const { t } = useTranslation()
-  function showRiskMultiplier(multiplier: number): string {
+  function formatRiskMultiplierInternal(multiplier: number): string {
     if (multiplier === 1) {
       return t('calculator.baseline_risk')
     } else if (multiplier > 0 && multiplier < 1) {
@@ -36,6 +36,12 @@ export const GenericSelectControl: React.FunctionComponent<{
     } else {
       return t('calculator.risk_modifier_multiple', { multiplier: multiplier })
     }
+  }
+  const formatRiskMultiplier = (multiplier?: number) => {
+    if (multiplier === undefined) {
+      return ''
+    }
+    return ` [${formatRiskMultiplierInternal(multiplier)}]`
   }
   return (
     <div className="form-group">
@@ -59,8 +65,8 @@ export const GenericSelectControl: React.FunctionComponent<{
         {Object.keys(props.source).map((value, index) => (
           <option key={index} value={value}>
             {props.source[value].label}{' '}
-            {props.hideRisk !== true &&
-              `[${showRiskMultiplier(props.source[value].multiplier)}]`}
+            {!props.hideRisk &&
+              formatRiskMultiplier(props.source[value].multiplier)}
           </option>
         ))}
         <IosOptgroup />
@@ -78,7 +84,7 @@ export const SelectControl: React.FunctionComponent<{
   id: keyof CalculatorData
   setter: (value: CalculatorData) => void
   data: CalculatorData
-  source: { [key: string]: FormValue }
+  source: { [key: string]: BaseFormValue }
   label?: string
   header?: string
   helpText?: string

--- a/src/data/__tests__/RiskProfile.test.ts
+++ b/src/data/__tests__/RiskProfile.test.ts
@@ -1,0 +1,134 @@
+import {
+  PersonRiskValue,
+  RiskProfile,
+  livingAloneMult,
+  personRiskMultiplier,
+} from 'data/data'
+
+const NO_BONUSES = {
+  isHousemate: false,
+  symptomsChecked: 'no',
+}
+
+const CHECKED = {
+  symptomsChecked: 'yes',
+}
+
+const CHECKED_THREE_DAYS = {
+  symptomsChecked: 'yesThreeDays',
+}
+
+describe('personRiskMultiplier', () => {
+  it('computes living alone', () => {
+    expect(
+      personRiskMultiplier({
+        riskProfile: RiskProfile['livingAlone'],
+        ...NO_BONUSES,
+      }),
+    ).toEqual(livingAloneMult)
+  })
+
+  it.each`
+    profile
+    ${'average'}
+    ${'frontline'}
+    ${'livingAlone'}
+    ${'bars'}
+  `(
+    'should not apply housemate or reporting bonuses for $profileName',
+    ({ profile }) => {
+      const base = { riskProfile: RiskProfile[profile], ...NO_BONUSES }
+      expect(personRiskMultiplier(base)).toEqual(
+        personRiskMultiplier({ ...base, isHousemate: true }),
+      )
+    },
+  )
+
+  it('reduces self-inflicted risk by 1/2 for checked or checked 3 days', () => {
+    const riskProfile: PersonRiskValue = {
+      label: 'dontcare',
+      personalMultiplier: 1,
+      numHousemates: 0,
+      numOtherTraceableContacts: 0,
+      contactsMultiplier: 1,
+    }
+    expect(
+      personRiskMultiplier({ riskProfile, isHousemate: false, ...CHECKED }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.5)
+    expect(
+      personRiskMultiplier({
+        riskProfile,
+        isHousemate: false,
+        ...CHECKED_THREE_DAYS,
+      }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.5)
+  })
+
+  it('reduces housemate to 1/4 risk for checked or checked 3 days', () => {
+    const riskProfile: PersonRiskValue = {
+      label: 'dontcare',
+      personalMultiplier: 0,
+      numHousemates: 2,
+      numOtherTraceableContacts: 0,
+      contactsMultiplier: 1,
+    }
+    expect(
+      personRiskMultiplier({ riskProfile, isHousemate: false, ...CHECKED }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.25)
+    expect(
+      personRiskMultiplier({
+        riskProfile,
+        isHousemate: false,
+        ...CHECKED_THREE_DAYS,
+      }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.25)
+  })
+
+  it('reduces number of housemates by one if isHousemate', () => {
+    const riskProfile: PersonRiskValue = {
+      label: 'dontcare',
+      personalMultiplier: 0,
+      numHousemates: 2,
+      numOtherTraceableContacts: 0,
+      contactsMultiplier: 1,
+    }
+
+    // Had 2 housemates, but one is the user, so there is only one actual housemate.
+    expect(
+      personRiskMultiplier({ riskProfile, ...NO_BONUSES, isHousemate: true }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.5)
+  })
+
+  it('reduces contact risk to 1/4 if checked and 1/14 if checked 3 days', () => {
+    const riskProfile: PersonRiskValue = {
+      label: 'dontcare',
+      personalMultiplier: 0,
+      numHousemates: 0,
+      numOtherTraceableContacts: 2,
+      contactsMultiplier: 1,
+    }
+    expect(
+      personRiskMultiplier({ riskProfile, isHousemate: false, ...CHECKED }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) * 0.25)
+    expect(
+      personRiskMultiplier({
+        riskProfile,
+        isHousemate: false,
+        ...CHECKED_THREE_DAYS,
+      }),
+    ).toBeCloseTo(personRiskMultiplier({ riskProfile, ...NO_BONUSES }) / 14)
+  })
+
+  it('does not remove non-housemate contacts if housemate is selected.', () => {
+    const riskProfile: PersonRiskValue = {
+      label: 'dontcare',
+      personalMultiplier: 0,
+      numHousemates: 0,
+      numOtherTraceableContacts: 2,
+      contactsMultiplier: 1,
+    }
+    expect(
+      personRiskMultiplier({ riskProfile, ...NO_BONUSES, isHousemate: true }),
+    ).toEqual(personRiskMultiplier({ riskProfile, ...NO_BONUSES }))
+  })
+})

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -16,10 +16,10 @@ import { prepopulated } from 'data/prepopulated'
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
 
 // The reported prevalence in |baseTestData|
-const BASE_RATE = 0.003
+const REPORTED_PREVALENCE = 0.003
 
 // The expected adjusted prevalence in |baseTestData|
-const RATE = 0.006
+const PREVALENCE = 0.006
 
 const dateAfterDay0 = (daysAfterDay0: number) => {
   const date = new Date()
@@ -27,7 +27,7 @@ const dateAfterDay0 = (daysAfterDay0: number) => {
   return date
 }
 
-// Prevailance is RATE (2x prevalance ratio)
+// Prevailance is PREVALENCE (2x prevalance ratio)
 const baseTestData = {
   riskBudget: BUDGET_ONE_PERCENT,
   subLocation: 'mock city',
@@ -37,7 +37,7 @@ const baseTestData = {
   casesIncreasingPercentage: 0,
   positiveCasePercentage: 0,
   prevalanceDataDate: dateAfterDay0(25), // prevalance ratio = 25 * positivity_rate ** 0.5 + 2
-  symptomFreeAndWillReportSymptoms: 0,
+  symptomsChecked: 'no',
 }
 
 // Variables that should be ignored for repeated/partner interactions.
@@ -72,12 +72,12 @@ const testData: (partial: Partial<CalculatorData>) => CalculatorData = (
 describe('calculateLocationPersonAverage', () => {
   it.each`
     positiveCasePercentage | result
-    ${0}                   | ${RATE}
-    ${4}                   | ${BASE_RATE * (0.04 ** 0.5 * 25 + 2)}
-    ${6}                   | ${BASE_RATE * (0.06 ** 0.5 * 25 + 2)}
-    ${16}                  | ${BASE_RATE * (0.16 ** 0.5 * 25 + 2)}
-    ${100}                 | ${BASE_RATE * (25 + 2)}
-    ${null}                | ${BASE_RATE * (25 + 2)}
+    ${0}                   | ${PREVALENCE}
+    ${4}                   | ${REPORTED_PREVALENCE * (0.04 ** 0.5 * 25 + 2)}
+    ${6}                   | ${REPORTED_PREVALENCE * (0.06 ** 0.5 * 25 + 2)}
+    ${16}                  | ${REPORTED_PREVALENCE * (0.16 ** 0.5 * 25 + 2)}
+    ${100}                 | ${REPORTED_PREVALENCE * (25 + 2)}
+    ${null}                | ${REPORTED_PREVALENCE * (25 + 2)}
   `(
     'should compensate for underreporting, positiveCasePercentage = $positiveCasePercentage',
     ({ positiveCasePercentage, result }) => {
@@ -89,10 +89,10 @@ describe('calculateLocationPersonAverage', () => {
 
   it.each`
     day    | result
-    ${0}   | ${BASE_RATE * ((0.25 ** 0.5 * 1250) / 25 + 2)}
-    ${25}  | ${BASE_RATE * ((0.25 ** 0.5 * 1250) / 50 + 2)}
-    ${50}  | ${BASE_RATE * ((0.25 ** 0.5 * 1250) / 75 + 2)}
-    ${300} | ${BASE_RATE * ((0.25 ** 0.5 * 1250) / 325 + 2)}
+    ${0}   | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1250) / 25 + 2)}
+    ${25}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1250) / 50 + 2)}
+    ${50}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1250) / 75 + 2)}
+    ${300} | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1250) / 325 + 2)}
   `(
     'should reduce the effect of positiveCasePercentage as 1250 / (days + 25), days = $day',
     ({ day, result }) => {
@@ -109,12 +109,12 @@ describe('calculateLocationPersonAverage', () => {
 
   it.each`
     casesIncreasingPercentage | result
-    ${0}                      | ${RATE}
-    ${-20}                    | ${RATE}
-    ${10}                     | ${RATE * 1.1}
-    ${50}                     | ${RATE * 1.5}
-    ${100}                    | ${RATE * 2.0}
-    ${200}                    | ${RATE * 2.0}
+    ${0}                      | ${PREVALENCE}
+    ${-20}                    | ${PREVALENCE}
+    ${10}                     | ${PREVALENCE * 1.1}
+    ${50}                     | ${PREVALENCE * 1.5}
+    ${100}                    | ${PREVALENCE * 2.0}
+    ${200}                    | ${PREVALENCE * 2.0}
   `(
     'should compensate for time delay',
     ({ casesIncreasingPercentage, result }) => {
@@ -132,7 +132,7 @@ describe('calculate', () => {
 
     const response = calcValue(data)
     // average * 2 people * outdoor * 1 hr * their mask * your mask
-    expect(response).toBe(((((RATE * 2) / 20) * 0.06) / 4 / 1) * 1e6)
+    expect(response).toBe(((((PREVALENCE * 2) / 20) * 0.06) / 4 / 1) * 1e6)
   })
 
   it.each`
@@ -174,13 +174,12 @@ describe('calculate', () => {
     })
 
     expect(calcValue(data)).toBeCloseTo(
-      RATE *
+      PREVALENCE *
         1e6 *
         personRiskMultiplier({
           riskProfile: RiskProfile['livingAlone'],
           isHousemate: false,
-          allSymptomFree: false,
-          willReport: false,
+          symptomsChecked: 'no',
         }),
     )
   })
@@ -259,14 +258,13 @@ describe('calculate', () => {
 
     it('should apply 48% risk', () => {
       expect(calcValue(partner)).toBeCloseTo(
-        RATE *
+        PREVALENCE *
           0.48 *
           1e6 *
           personRiskMultiplier({
             riskProfile: RiskProfile['livingAlone'],
             isHousemate: false,
-            allSymptomFree: false,
-            willReport: false,
+            symptomsChecked: 'no',
           }),
       )
     })
@@ -304,7 +302,22 @@ describe('calculate', () => {
 
     it('should apply 30% risk', () => {
       // average * 0.3
-      expect(calcValue(housemate)).toEqual(RATE * 0.3 * 1e6)
+      expect(calcValue(housemate)).toEqual(PREVALENCE * 0.3 * 1e6)
+    })
+
+    it('should remove the risk from the user for risk profiles including housemates', () => {
+      const housemateData = testData({
+        riskProfile: 'closedPod4',
+        interaction: 'repeated',
+      })
+      const equivalentOneTime = testData({
+        riskProfile: 'closdedPod4',
+        interaction: 'oneTime',
+        duration: 60 * 5,
+      })
+      expect(calcValue(housemateData)).toBeCloseTo(
+        (calcValue(equivalentOneTime)! * (1 + 0.3 * 2)) / (1 + 0.3 / 3),
+      )
     })
   })
 

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -5,7 +5,12 @@ import {
   calculateLocationPersonAverage,
   defaultValues,
 } from 'data/calculate'
-import { BUDGET_ONE_PERCENT, RiskProfile, RiskProfileEnum } from 'data/data'
+import {
+  BUDGET_ONE_PERCENT,
+  RiskProfile,
+  RiskProfileEnum,
+  personRiskMultiplier,
+} from 'data/data'
 import { prepopulated } from 'data/prepopulated'
 
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
@@ -32,6 +37,7 @@ const baseTestData = {
   casesIncreasingPercentage: 0,
   positiveCasePercentage: 0,
   prevalanceDataDate: dateAfterDay0(25), // prevalance ratio = 25 * positivity_rate ** 0.5 + 2
+  symptomFreeAndWillReportSymptoms: 0,
 }
 
 // Variables that should be ignored for repeated/partner interactions.
@@ -168,7 +174,14 @@ describe('calculate', () => {
     })
 
     expect(calcValue(data)).toBeCloseTo(
-      RATE * RiskProfile['livingAlone']['multiplier'] * 1e6,
+      RATE *
+        1e6 *
+        personRiskMultiplier({
+          riskProfile: RiskProfile['livingAlone'],
+          isHousemate: false,
+          allSymptomFree: false,
+          willReport: false,
+        }),
     )
   })
 
@@ -245,8 +258,16 @@ describe('calculate', () => {
     })
 
     it('should apply 48% risk', () => {
-      expect(calcValue(partner)).toEqual(
-        RATE * RiskProfile.livingAlone.multiplier * 0.48 * 1e6,
+      expect(calcValue(partner)).toBeCloseTo(
+        RATE *
+          0.48 *
+          1e6 *
+          personRiskMultiplier({
+            riskProfile: RiskProfile['livingAlone'],
+            isHousemate: false,
+            allSymptomFree: false,
+            willReport: false,
+          }),
       )
     })
   })
@@ -278,7 +299,7 @@ describe('calculate', () => {
         voice: 'silent',
       }
 
-      expect(calcValue(housemate)).toEqual(calcValue(bonuses))
+      expect(calcValue(housemate)).toBeCloseTo(calcValue(bonuses)!)
     })
 
     it('should apply 30% risk', () => {

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -34,7 +34,7 @@ export interface CalculatorData {
   riskProfile: keyof typeof RiskProfile
   interaction: string
   personCount: number
-  symptomFreeAndWillReportSymptoms: number // Treated as boolean
+  symptomsChecked: string
 
   // Activity risk
   setting: string
@@ -59,7 +59,7 @@ export const defaultValues: CalculatorData = {
   riskProfile: '',
   interaction: '',
   personCount: 0,
-  symptomFreeAndWillReportSymptoms: 0,
+  symptomsChecked: 'no',
 
   setting: '',
   distance: '',
@@ -209,15 +209,13 @@ export const calculatePersonRiskEach = (
       // If risk profile isn't selected, call it incomplete
       return null
     }
-    const riskProfile = RiskProfile[data.riskProfile]
     const isHousemate = data.interaction !== 'oneTime'
     return (
       averagePersonRisk *
       personRiskMultiplier({
-        riskProfile,
+        riskProfile: RiskProfile[data.riskProfile],
         isHousemate,
-        allSymptomFree: data.symptomFreeAndWillReportSymptoms === 1,
-        willReport: data.symptomFreeAndWillReportSymptoms === 1,
+        symptomsChecked: data.symptomsChecked,
       })
     )
   } catch (e) {

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -7,10 +7,22 @@ export interface CheckBoxFormValue extends FormValue {
   sublabel?: string
 }
 
-export interface FormValue {
+export interface BaseFormValue {
   label: string
+  multiplier?: number
+}
+
+export interface FormValue extends BaseFormValue {
   multiplier: number
   housemateMultiplier?: number // Different multiplier to apply if the contact is a housemate.
+}
+
+export interface PersonRiskValue extends BaseFormValue {
+  label: string
+  personalMultiplier: number
+  numHousemates: number
+  numOtherTraceableContacts: number // Not including housemates
+  contactsMultiplier: number
 }
 
 const formValue = function (label: string, multiplier: number): FormValue {
@@ -112,6 +124,7 @@ export const budgetOptions = [
   },
 ]
 
+// TODO(beshaya): Move RiskProfile to it's own file.
 /*
  * Exposed to ten (silent distanced masked) average people indoors,
  * while wearing a surgical mask, one-time, for one hour per week.
@@ -125,69 +138,129 @@ const livingAloneMult =
   Interaction.oneTime.multiplier *
   Setting.indoor.multiplier
 
-export const RiskProfile: { [key: string]: FormValue } = {
+const SYMPTOM_FREE_MULT = 0.5
+const WILL_REPORT_MULT = 0.5
+
+export const personRiskMultiplier: (arg: {
+  riskProfile: PersonRiskValue
+  isHousemate: boolean
+  allSymptomFree: boolean
+  willReport: boolean
+}) => number = ({ riskProfile, isHousemate, allSymptomFree, willReport }) => {
+  const symptomFreeMult = allSymptomFree ? SYMPTOM_FREE_MULT : 1
+  const willReportMult = willReport ? WILL_REPORT_MULT : 1
+
+  // Remove the person doing the calculation from the number of contacts if applicable.
+  const housematesNotIncludingUser = Math.max(
+    0,
+    riskProfile.numHousemates - (isHousemate ? 1 : 0),
+  )
+  const totalContacts =
+    housematesNotIncludingUser + riskProfile.numOtherTraceableContacts
+
+  const allContactsRisk =
+    riskProfile.contactsMultiplier *
+    totalContacts *
+    housemateMult *
+    symptomFreeMult *
+    willReportMult
+  return (riskProfile.personalMultiplier + allContactsRisk) * symptomFreeMult
+}
+
+// Shorthands for filling in RiskProfiles with no contacts
+const noContacts = {
+  numHousemates: 0,
+  numOtherTraceableContacts: 0,
+  contactsMultiplier: 0,
+}
+
+export const RiskProfile: { [key: string]: PersonRiskValue } = {
   average: {
     label: i18n.t('data.person.average'),
-    multiplier: 1,
+    personalMultiplier: 1.0,
+    ...noContacts,
   },
 
   frontline: {
     label: i18n.t('data.person.frontline'),
-    multiplier: 3,
+    personalMultiplier: 3.0,
+    ...noContacts,
   },
 
   nonFrontline: {
     label: i18n.t('data.person.nonFrontline'),
-    multiplier: 0.5,
+    personalMultiplier: 0.5,
+    ...noContacts,
   },
 
   livingAlone: {
     label: i18n.t('data.person.livingAlone'),
-    multiplier: livingAloneMult,
+    personalMultiplier: livingAloneMult,
+    ...noContacts,
   },
 
   livingWithPartner: {
     label: i18n.t('data.person.livingWithPartner'),
-    multiplier: (1 + 0.48) * livingAloneMult,
-    housemateMultiplier: livingAloneMult,
+    personalMultiplier: livingAloneMult,
+    numHousemates: 1,
+    numOtherTraceableContacts: 0,
+    contactsMultiplier: livingAloneMult,
   },
 
   closedPod4: {
     label: i18n.t('data.person.closedPod4'),
-    multiplier: (1 + 4 * housemateMult) * livingAloneMult,
-    housemateMultiplier: (1 + 3 * housemateMult) * livingAloneMult,
+    personalMultiplier: livingAloneMult,
+    numHousemates: 3,
+    numOtherTraceableContacts: 0,
+    contactsMultiplier: livingAloneMult,
   },
 
   closedPod10: {
     label: i18n.t('data.person.closedPod10'),
-    multiplier: (1 + 10 * housemateMult) * livingAloneMult,
-    housemateMultiplier: (1 + 9 * housemateMult) * livingAloneMult,
+    personalMultiplier: livingAloneMult,
+    numHousemates: 9,
+    numOtherTraceableContacts: 0,
+    contactsMultiplier: livingAloneMult,
   },
 
   closedPod20: {
     label: i18n.t('data.person.closedPod20'),
-    multiplier: (1 + 20 * housemateMult) * livingAloneMult,
-    housemateMultiplier: (1 + 19 * housemateMult) * livingAloneMult,
+    personalMultiplier: livingAloneMult,
+    numHousemates: 19,
+    numOtherTraceableContacts: 0,
+    contactsMultiplier: livingAloneMult,
   },
 
   contact1: {
     label: i18n.t('data.person.contact1'),
-    multiplier: housemateMult * 0.5 + livingAloneMult, // Housemate + grocery exposure
+    personalMultiplier: livingAloneMult,
+    numHousemates: 0,
+    numOtherTraceableContacts: 1,
+    contactsMultiplier: 1,
   },
 
   contact4: {
     label: i18n.t('data.person.contact4'),
-    multiplier: 4 * housemateMult * 0.5 + livingAloneMult, // Housemate + grocery exposure
+    personalMultiplier: livingAloneMult,
+    numHousemates: 0,
+    numOtherTraceableContacts: 3,
+    contactsMultiplier: 1,
   },
 
   contact10: {
     label: i18n.t('data.person.contact10'),
-    multiplier: 10 * housemateMult * 0.5 + livingAloneMult, // Housemate + grocery exposure
+    personalMultiplier: livingAloneMult,
+    numHousemates: 0,
+    numOtherTraceableContacts: 9,
+    contactsMultiplier: 1,
   },
 
   contactWorks: {
     label: i18n.t('data.person.contactWorks'),
-    multiplier: housemateMult * 3 + livingAloneMult, // Housemate + grocery exposure
+    personalMultiplier: livingAloneMult,
+    numHousemates: 0,
+    numOtherTraceableContacts: 3,
+    contactsMultiplier: 1.0,
   },
 
   bars: {
@@ -196,10 +269,11 @@ export const RiskProfile: { [key: string]: FormValue } = {
      * Six hours of indoor exposure to a dozen people (2 near you, 10 six feet away)
      * who are not wearing masks and are talking loudly.
      */
-    multiplier:
+    personalMultiplier:
       6 *
       Interaction.oneTime.multiplier *
       (2 + 10 * Distance.sixFt.multiplier * Voice.loud.multiplier),
+    ...noContacts,
   },
 }
 
@@ -212,15 +286,24 @@ export const RiskProfileEnum = {
 
 RiskProfile[RiskProfileEnum.ONE_PERCENT] = {
   label: i18n.t('data.person.microcovid_budget_one_percent'),
-  multiplier: NaN,
+  personalMultiplier: NaN,
+  numHousemates: NaN,
+  numOtherTraceableContacts: NaN,
+  contactsMultiplier: NaN,
 }
 
 RiskProfile[RiskProfileEnum.DECI_PERCENT] = {
   label: i18n.t('data.person.microcovid_budget_deci_percent'),
-  multiplier: NaN,
+  personalMultiplier: NaN,
+  numHousemates: NaN,
+  numOtherTraceableContacts: NaN,
+  contactsMultiplier: NaN,
 }
 
 RiskProfile[RiskProfileEnum.HAS_COVID] = {
   label: i18n.t('data.person.hasCovid'),
-  multiplier: -1,
+  personalMultiplier: NaN,
+  numHousemates: NaN,
+  numOtherTraceableContacts: NaN,
+  contactsMultiplier: NaN,
 }

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -11,11 +11,7 @@ export type PartialData = Omit<
   | 'casesPastWeek'
   | 'casesIncreasingPercentage'
   | 'positiveCasePercentage'
-<<<<<<< HEAD
   | 'prevalanceDataDate'
-=======
-  | 'symptomFreeAndWillReportSymptoms'
->>>>>>> Refactor RiskProfile to explicitly calculate risk from basics
 >
 
 export const prepopulated: {
@@ -25,6 +21,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 2,
+    symptomsChecked: 'no',
 
     setting: 'outdoor',
     distance: 'normal',
@@ -38,6 +35,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 2,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'normal',
@@ -51,6 +49,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 1,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'normal',
@@ -64,6 +63,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 1,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'intimate',
@@ -77,6 +77,7 @@ export const prepopulated: {
     riskProfile: 'livingAlone',
     interaction: 'partner',
     personCount: 1,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'intimate',
@@ -90,6 +91,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 5,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'sixFt',
@@ -103,6 +105,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 20,
+    symptomsChecked: 'no',
 
     setting: 'plane',
     distance: 'normal',
@@ -116,6 +119,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 15,
+    symptomsChecked: 'no',
 
     setting: 'outdoor',
     distance: 'sixFt',
@@ -129,6 +133,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 15,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'sixFt',
@@ -142,6 +147,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 15,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'sixFt',
@@ -155,6 +161,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 80,
+    symptomsChecked: 'no',
 
     setting: 'outdoor',
     distance: 'normal',
@@ -168,6 +175,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 25,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'normal',
@@ -181,6 +189,7 @@ export const prepopulated: {
     riskProfile: 'hasCovid',
     interaction: 'oneTime',
     personCount: 1,
+    symptomsChecked: 'no',
 
     setting: 'outdoor',
     distance: 'normal',
@@ -194,6 +203,7 @@ export const prepopulated: {
     riskProfile: 'average',
     interaction: 'oneTime',
     personCount: 2,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'sixFt',
@@ -207,6 +217,7 @@ export const prepopulated: {
     riskProfile: 'hasCovid',
     interaction: 'oneTime',
     personCount: 1,
+    symptomsChecked: 'no',
 
     setting: 'indoor',
     distance: 'normal',

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -11,7 +11,11 @@ export type PartialData = Omit<
   | 'casesPastWeek'
   | 'casesIncreasingPercentage'
   | 'positiveCasePercentage'
+<<<<<<< HEAD
   | 'prevalanceDataDate'
+=======
+  | 'symptomFreeAndWillReportSymptoms'
+>>>>>>> Refactor RiskProfile to explicitly calculate risk from basics
 >
 
 export const prepopulated: {


### PR DESCRIPTION
- Create a feature branch for work to help with high prevalence situations + add to CI
- Breaks down RiskProfile calculation in individual's actions, # of housemate's, # of other traceable contacts; standardizes how RiskProfile is calculated
- Adds hooks for adding "symptom free" features

That this change makes no user-facing changes (except adding a new parameter in the url) - verified by calculate.test.ts