### PR TITLE
i18n: added Norwegian translation to the selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,7 @@ export const App = (): React.ReactElement => {
                     <Dropdown.Item href="?lng=de">Deutsch</Dropdown.Item>
                     <Dropdown.Item href="?lng=fr">Français</Dropdown.Item>
                     <Dropdown.Item href="?lng=hu">Magyar</Dropdown.Item>
+                    <Dropdown.Item href="?lng=nb">Norsk</Dropdown.Item>
                   </DropdownButton>
                 </Nav>
               </Navbar.Collapse>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -7,6 +7,7 @@ import de from './locales/de.json'
 import en from './locales/en.json'
 import fr from './locales/fr.json'
 import hu from './locales/hu.json'
+import nb from './locales/nb_NO.json'
 
 i18n
   .use(LanguageDetector)
@@ -18,6 +19,7 @@ i18n
       de: { translation: de },
       hu: { translation: hu },
       cs: { translation: cs },
+      nb: { translation: nb },
     },
     fallbackLng: 'en',
     keySeparator: '.',


### PR DESCRIPTION
There is now a fairly complete and well-reviewed Norwegian (Bokmål) translation available on Weblate, so it was time to add it to the language selector.