### PR TITLE
Fix PrevalenceFields' display logic

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -310,7 +310,7 @@ export const PrevalenceControls: React.FunctionComponent<{
             setter({ ...data, casesPastWeek: parseInt(value || '') })
           }
           inputType="number"
-          isEditable={!locationSet}
+          isEditable={isManualEntryCurrently}
           className="hide-number-buttons"
         />
         <PrevalenceField
@@ -319,7 +319,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           value={data.population}
           setter={(value) => setter({ ...data, population: value })}
           inputType="text"
-          isEditable={!locationSet}
+          isEditable={isManualEntryCurrently}
           className="hide-number-buttons"
         />
         {locationSet && data.casesIncreasingPercentage === 0 ? (
@@ -335,7 +335,7 @@ export const PrevalenceControls: React.FunctionComponent<{
             }}
             inputType="number"
             min={0}
-            isEditable={!locationSet}
+            isEditable={isManualEntryCurrently}
             className="hide-number-buttons"
           />
         )}
@@ -361,7 +361,7 @@ export const PrevalenceControls: React.FunctionComponent<{
             inputType="number"
             max={100}
             min={0}
-            isEditable={!locationSet}
+            isEditable={isManualEntryCurrently}
             className="hide-number-buttons"
           />
         )}


### PR DESCRIPTION
PR was requested [here](https://github.com/microcovid/microcovid/pull/326#issuecomment-760600469).

When the location is set to 'Select location', and the Details drop-down is open, the fields were editable. The isEditable used the slightly wrong method which checks whether the top location has been set. This commit irons out that edge case.