### PR TITLE
Show results of prevalence calculation when in manual data mode

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -300,7 +300,7 @@ export const PrevalenceControls: React.FunctionComponent<{
         open={detailsOpen}
         setter={setDetailsOpen}
       >
-        {!isManualEntryCurrently && <PrevalenceResult data={data} />}
+        <PrevalenceResult data={data} />
 
         <PrevalenceField
           id="reported-cases"


### PR DESCRIPTION
@blanchardjeremy [says](https://github.com/microcovid/microcovid/pull/326\#issuecomment-760626478):

> After the user types in the manual data, I think they should see the actual
prevalence and adjusted prevalence numbers still.

This commit removes the logic which hides the calculated prevalence numbers during manual data entry mode.