### PR TITLE
Move prebuilt activities to the person-risk card.

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -237,6 +237,7 @@ export const PrevalenceControls: React.FunctionComponent<{
         />
         <Typeahead
           clearButton={true}
+          highlightOnlyResult={true}
           id="top-location-typeahead"
           onChange={(e: Option[]) => {
             if (e.length !== 1) {
@@ -260,6 +261,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           />
           <Typeahead
             clearButton={true}
+            highlightOnlyResult={true}
             id="sub-location-typeahead"
             onChange={(e: Option[]) => {
               if (e.length !== 1) {

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Form } from 'react-bootstrap'
+import { Form, InputGroup } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import { useTranslation } from 'react-i18next'
+import { BsSearch } from 'react-icons/bs'
 
 import { CalculatorData } from 'data/calculate'
 import { PartialData, prepopulated } from 'data/prepopulated'
@@ -31,21 +32,29 @@ export const SavedDataSelector: React.FunctionComponent<{
 
   return (
     <Form.Group>
-      <Typeahead
-        clearButton={true}
-        id="predefined-typeahead"
-        onChange={(e: string[]) => {
-          if (e.length !== 1) {
-            setSavedData('')
+      <InputGroup>
+        <InputGroup.Prepend>
+          <InputGroup.Text>
+            <BsSearch />
+          </InputGroup.Text>
+        </InputGroup.Prepend>
+        <Typeahead
+          clearButton={true}
+          highlightOnlyResult={true}
+          id="predefined-typeahead"
+          onChange={(e: string[]) => {
+            if (e.length !== 1) {
+              setSavedData('')
+            }
+            setSavedData(e[0])
+          }}
+          options={prepopulatedOptions}
+          placeholder={t('calculator.select_scenario')}
+          defaultSelected={
+            props.scenarioName in prepopulated ? [props.scenarioName] : []
           }
-          setSavedData(e[0])
-        }}
-        options={prepopulatedOptions}
-        placeholder={t('calculator.select_scenario')}
-        defaultSelected={
-          props.scenarioName in prepopulated ? [props.scenarioName] : []
-        }
-      />
+        />
+      </InputGroup>
     </Form.Group>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -125,7 +125,7 @@
       "enter_data_manually": "Switch to manual data entry mode"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), and <7>Our World in Data</7> (international positive test rates).",
-    "select_scenario": "Optional: Start with a predefined common activity",
+    "select_scenario": "Search for an activity or build your own below...",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
     "risk_modifier_frac_3rd": "{{frac}}rd the risk",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -173,16 +173,6 @@ export const Calculator = (): React.ReactElement => {
           </h2>
         </Col>
       </Row>
-      <Row>
-        <Col className="calculator-buttons">
-          <SavedDataSelector
-            currentData={calculatorData}
-            setter={setCalculatorData}
-            scenarioName={scenarioName}
-            scenarioNameSetter={setScenarioName}
-          />
-        </Col>
-      </Row>
       <Row id="calculator-fields">
         <Col md="12" lg="4">
           <Card id="location">
@@ -200,6 +190,16 @@ export const Calculator = (): React.ReactElement => {
                 <header id="activity-risk">
                   <Trans>calculator.risk_step_label</Trans>
                 </header>
+                <Row>
+                  <Col className="calculator-buttons">
+                    <SavedDataSelector
+                      currentData={calculatorData}
+                      setter={setCalculatorData}
+                      scenarioName={scenarioName}
+                      scenarioNameSetter={setScenarioName}
+                    />
+                  </Col>
+                </Row>
                 {!scenarioName ? null : (
                   <Alert variant="info">
                     <Trans values={{ scenarioName: scenarioName }}>


### PR DESCRIPTION
It was previously below the call to action.

Make some related UX tweaks too:

* adjust header styles to deemphasize location and highlight
  activity/relationship now that location autofills
* remove explicit step numbers now that location autofills
* adjust prebuilt activities box instructions so that the most important
  words for understanding are clustered at the beginning of the phrase

* add magnifying glass affordance to prebuilt activity search to more
  strongly indicate that it's for typing (it's indistinguishable from
the other dropdowns. This isn't a perfect solution but will do for now.)