### PR TITLE
Remove "Within 15 feet" tooltip from People input

### DIFF
--- a/src/components/calculator/PersonRiskControls.tsx
+++ b/src/components/calculator/PersonRiskControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form, Popover } from 'react-bootstrap'
+import { Popover } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 
 import ControlLabel from './controls/ControlLabel'
@@ -99,9 +99,6 @@ export const PersonRiskControls: React.FunctionComponent<{
               })
             }
           />
-          <Form.Text id={'personCount HelpText'} muted>
-            Within 15 feet
-          </Form.Text>
           <GroupSizeWarning people={data.personCount} />
         </div>
       )}


### PR DESCRIPTION
With ccbfa0fe the description above the input field already contains the "within 15 feet" request so this is redundant, and it was also never localized, so let's just get rid of it.