### PR TITLE
Small miscellaneous UX tweaks in prevalence box and activity search

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -170,6 +170,7 @@ export const PrevalenceControls: React.FunctionComponent<{
 
   const handleSelectLocationButtonOnClick = () => {
     setLocationData('', '')
+    setDetailsOpen(false)
   }
 
   // If a stored location exists, load latest data for that location.
@@ -239,6 +240,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           clearButton={true}
           highlightOnlyResult={true}
           id="top-location-typeahead"
+          inputProps={{ autoComplete: 'off' }}
           onChange={(e: Option[]) => {
             if (e.length !== 1) {
               setLocationData('', '')
@@ -263,6 +265,7 @@ export const PrevalenceControls: React.FunctionComponent<{
             clearButton={true}
             highlightOnlyResult={true}
             id="sub-location-typeahead"
+            inputProps={{ autoComplete: 'chrome-off' }}
             onChange={(e: Option[]) => {
               if (e.length !== 1) {
                 setLocationData(data.topLocation, '')
@@ -279,21 +282,25 @@ export const PrevalenceControls: React.FunctionComponent<{
         </div>
       )}
       {isManualEntryCurrently ? (
-        <button
-          id="switchBetweenManualDataAndLocationSelection"
-          className="btn btn-secondary"
-          onClick={handleSelectLocationButtonOnClick}
-        >
-          {t('calculator.switch_button.select_location')}
-        </button>
+        <span>
+          <button
+            id="switchBetweenManualDataAndLocationSelection"
+            className="btn btn-link text-muted"
+            onClick={handleSelectLocationButtonOnClick}
+          >
+            {t('calculator.switch_button.select_location')}
+          </button>
+        </span>
       ) : (
-        <button
-          id="switchBetweenManualDataAndLocationSelection"
-          className="btn btn-secondary"
-          onClick={handleEnterDataButtonOnClick}
-        >
-          {t('calculator.switch_button.enter_data_manually')}
-        </button>
+        <span>
+          <button
+            id="switchBetweenManualDataAndLocationSelection"
+            className="btn btn-link text-muted"
+            onClick={handleEnterDataButtonOnClick}
+          >
+            {t('calculator.switch_button.enter_data_manually')}
+          </button>
+        </span>
       )}
       <ControlledExpandable
         id="prevalence-details"

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -40,8 +40,10 @@ export const SavedDataSelector: React.FunctionComponent<{
         </InputGroup.Prepend>
         <Typeahead
           clearButton={true}
+          emptyLabel={t('calculator.no_prebuilt_scenario_found')}
           highlightOnlyResult={true}
           id="predefined-typeahead"
+          inputProps={{ autoComplete: 'off' }}
           onChange={(e: string[]) => {
             if (e.length !== 1) {
               setSavedData('')

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,6 +126,7 @@
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), and <7>Our World in Data</7> (international positive test rates).",
     "select_scenario": "Search for an activity or build your own below...",
+    "no_prebuilt_scenario_found": "We don't have this scenario yet, but you can build your own below.",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
     "risk_modifier_frac_3rd": "{{frac}}rd the risk",


### PR DESCRIPTION
* Add custom error message encouraging people to modify calculator
  values directly if there is no preset.
* Disable autofill addresses on the country, state and activity search
  typeaheads.
* Make the "switch to manual data entry mode" button smaller and boring
  (like an email unsubscribe button) so that people are less likely to
  hit it on autopilot
* Hide details if someone clicks "Switch to pre-populated location
  data". If someone is clicking on this button they probably want to
  reset back to the previous view.