### PR TITLE
Toggle prevalence manual data entry with a checkbox.

### DIFF
--- a/src/components/calculator/PrevalenceControls.tsx
+++ b/src/components/calculator/PrevalenceControls.tsx
@@ -2,9 +2,10 @@ import i18n from 'i18n'
 import countries from 'i18n-iso-countries'
 import { isNumber } from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { Card, Form, InputGroup } from 'react-bootstrap'
+import { Card, Form, InputGroup, ToggleButton } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import { Trans, useTranslation } from 'react-i18next'
+import { BsDash } from 'react-icons/bs'
 
 import ControlLabel from './controls/ControlLabel'
 import { ControlledExpandable } from 'components/Expandable'
@@ -13,7 +14,6 @@ import {
   calculateLocationPersonAverage,
   calculateLocationReportedPrevalence,
 } from 'data/calculate'
-import { TOP_LOCATION_MANUAL_ENTRY } from 'data/data'
 import { Locations, PrevalenceDataDate } from 'data/location'
 import 'components/calculator/styles/PrevalenceControls.scss'
 
@@ -30,8 +30,18 @@ const isTopLocation = (val: string): boolean => {
   return isFilled(val) && !!Locations[val]
 }
 
-const isManualEntry = (val: string): boolean => {
-  return val === TOP_LOCATION_MANUAL_ENTRY
+const PrevalenceFieldStatic: React.FunctionComponent<{
+  id: string
+  label: string
+  value: string | number
+  unit?: string
+}> = ({ id, label, value, unit }): React.ReactElement => {
+  return (
+    <div id={id}>
+      {label}: {typeof value === 'number' ? value.toLocaleString() : value}
+      {unit}
+    </div>
+  )
 }
 
 const PrevalenceField: React.FunctionComponent<{
@@ -41,7 +51,6 @@ const PrevalenceField: React.FunctionComponent<{
   unit?: string
   setter: (newValue: string) => void
   inputType: string
-  isEditable: boolean
   max?: number
   min?: number
   helpText?: string
@@ -53,26 +62,17 @@ const PrevalenceField: React.FunctionComponent<{
   setter,
   unit,
   inputType,
-  isEditable,
   max,
   min,
   helpText,
   className,
 }): React.ReactElement => {
-  if (!isEditable) {
-    return (
-      <div>
-        {label}: {typeof value === 'number' ? value.toLocaleString() : value}
-        {unit}
-      </div>
-    )
-  }
   let body: React.ReactElement = (
     <Form.Control
       className={'form-control form-control-lg col-md-3 col-lg-6 ' + className}
       type={inputType}
       value={value}
-      readOnly={!isEditable}
+      readOnly={false}
       onChange={(e) => {
         if (isNumber(max) || isNumber(min)) {
           let newValue = Number.parseFloat(e.target.value)
@@ -160,9 +160,6 @@ export const PrevalenceControls: React.FunctionComponent<{
   }
 
   const setLocationData = (topLocation: string, subLocation: string) => {
-    if (isManualEntry(topLocation)) {
-      setDetailsOpen(true)
-    }
     setter({
       ...data,
       ...dataForLocation(subLocation || topLocation),
@@ -171,18 +168,33 @@ export const PrevalenceControls: React.FunctionComponent<{
     })
   }
 
-  const handleEnterDataButtonOnClick = () => {
-    setLocationData(TOP_LOCATION_MANUAL_ENTRY, '')
-  }
+  const setManualPrevalenceData = (isManualEntry: boolean) => {
+    setIsManualEntryCurrently(isManualEntry)
+    const useManualEntry = isManualEntry ? 1 : 0
 
-  const handleSelectLocationButtonOnClick = () => {
-    setLocationData('', '')
-    setDetailsOpen(false)
+    if (isManualEntry) {
+      setter({
+        ...data,
+        useManualEntry,
+      })
+    } else if (!isManualEntry) {
+      // Going back to location mode. Reset location data so that details match the selected country/state and region.
+      const topLocation = data.topLocation
+      const subLocation = data.subLocation
+      setter({
+        ...data,
+        ...dataForLocation(subLocation || topLocation),
+        useManualEntry,
+      })
+    }
   }
 
   // If a stored location exists, load latest data for that location.
   useEffect(() => {
-    if (isFilled(data.subLocation) || isTopLocation(data.topLocation)) {
+    if (
+      !data.useManualEntry &&
+      (isFilled(data.subLocation) || isTopLocation(data.topLocation))
+    ) {
       setLocationData(data.topLocation, data.subLocation)
     }
     // Intentionally not depending on data so that this runs once on mount.
@@ -204,9 +216,11 @@ export const PrevalenceControls: React.FunctionComponent<{
     isTopLocation(data.topLocation) &&
     Locations[data.topLocation].subdivisions.length > 1
 
-  const locationSet = isTopLocation(data.topLocation)
+  const locationSet = !data.useManualEntry && isTopLocation(data.topLocation)
 
-  const isManualEntryCurrently = isManualEntry(data.topLocation)
+  const [isManualEntryCurrently, setIsManualEntryCurrently] = useState<boolean>(
+    !!data.useManualEntry,
+  )
 
   const [detailsOpen, setDetailsOpen] = useState(
     false || isManualEntryCurrently,
@@ -256,16 +270,17 @@ export const PrevalenceControls: React.FunctionComponent<{
       <header id="location">
         <Trans>calculator.location_selector_header</Trans>
       </header>
-      <div className="form-group" hidden={isManualEntryCurrently}>
+      <div className="form-group">
         <ControlLabel
           id="top-location-typeahead"
           header={t('calculator.select_location_label')}
         />
         <Typeahead
           clearButton={true}
+          disabled={isManualEntryCurrently}
           highlightOnlyResult={true}
           id="top-location-typeahead"
-          inputProps={{ autoComplete: 'off' }}
+          inputProps={{ autoComplete: 'chrome-off' }}
           onChange={(e: Option[]) => {
             if (e.length !== 1) {
               setLocationData('', '')
@@ -280,7 +295,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           }
         />
       </div>
-      {!showSubLocation ? null : (
+      {showSubLocation && (
         <div className="form-group">
           <ControlLabel
             id="sub-location-typeahead"
@@ -288,6 +303,7 @@ export const PrevalenceControls: React.FunctionComponent<{
           />
           <Typeahead
             clearButton={true}
+            disabled={isManualEntryCurrently}
             highlightOnlyResult={true}
             id="sub-location-typeahead"
             inputProps={{ autoComplete: 'chrome-off' }}
@@ -306,59 +322,48 @@ export const PrevalenceControls: React.FunctionComponent<{
           />
         </div>
       )}
-      {isManualEntryCurrently ? (
-        <span>
-          <button
-            id="switchBetweenManualDataAndLocationSelection"
-            className="btn btn-link text-muted"
-            onClick={handleSelectLocationButtonOnClick}
-          >
-            {t('calculator.switch_button.select_location')}
-          </button>
-        </span>
-      ) : (
-        <span>
-          <button
-            id="switchBetweenManualDataAndLocationSelection"
-            className="btn btn-link text-muted"
-            onClick={handleEnterDataButtonOnClick}
-          >
+      <span>
+        <ToggleButton
+          id="switchBetweenManualDataAndLocationSelection"
+          name={t('calculator.switch_button.select_location')}
+          type="checkbox"
+          checked={isManualEntryCurrently}
+          value="1"
+          variant="link"
+          className="text-muted"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setManualPrevalenceData(e.currentTarget.checked)
+          }}
+        >
+          <span id="switchBetweenManualDataAndLocationSelectionText">
             {t('calculator.switch_button.enter_data_manually')}
-          </button>
-        </span>
-      )}
-      <ControlledExpandable
-        id="prevalence-details"
-        header={t('calculator.prevalence.details_header')}
-        headerClassName={isManualEntryCurrently ? 'd-none' : ''}
-        open={detailsOpen}
-        setter={setDetailsOpen}
-      >
-        <PrevalenceResult data={data} />
-
-        <PrevalenceField
-          id="reported-cases"
-          label={t('calculator.prevalence.last_week_cases')}
-          value={data.casesPastWeek || 0}
-          setter={(value) =>
-            setter({ ...data, casesPastWeek: parseInt(value || '') })
-          }
-          inputType="number"
-          isEditable={isManualEntryCurrently}
-          className="hide-number-buttons"
-        />
-        <PrevalenceField
-          id="population"
-          label={t('calculator.prevalence.population')}
-          value={data.population}
-          setter={(value) => setter({ ...data, population: value })}
-          inputType="text"
-          isEditable={isManualEntryCurrently}
-          className="hide-number-buttons"
-        />
-        {locationSet && data.casesIncreasingPercentage === 0 ? (
-          <div>{t('calculator.prevalence.cases_stable_or_decreasing')}</div>
-        ) : (
+          </span>
+        </ToggleButton>
+      </span>
+      {isManualEntryCurrently ? (
+        <div id="prevalence-details">
+          <span id="details-header">
+            <BsDash /> {t('calculator.prevalence.details_header')}
+          </span>
+          <PrevalenceResult data={data} />
+          <PrevalenceField
+            id="reported-cases"
+            label={t('calculator.prevalence.last_week_cases')}
+            value={data.casesPastWeek || 0}
+            setter={(value) =>
+              setter({ ...data, casesPastWeek: parseInt(value || '') })
+            }
+            inputType="number"
+            className="hide-number-buttons"
+          />
+          <PrevalenceField
+            id="population"
+            label={t('calculator.prevalence.population')}
+            value={data.population}
+            setter={(value) => setter({ ...data, population: value })}
+            inputType="text"
+            className="hide-number-buttons"
+          />
           <PrevalenceField
             id="percent-increase"
             label={t('calculator.prevalence.percent_increase_in_cases')}
@@ -369,25 +374,16 @@ export const PrevalenceControls: React.FunctionComponent<{
             }}
             inputType="number"
             min={0}
-            isEditable={isManualEntryCurrently}
             className="hide-number-buttons"
           />
-        )}
-        {data.positiveCasePercentage === null ? (
           <PrevalenceField
             id="positive-test-rate"
             label={t('calculator.prevalence.positive_case_percentage')}
-            value="no data available"
-            unit="%"
-            setter={(_value) => null}
-            inputType="text"
-            isEditable={false}
-          />
-        ) : (
-          <PrevalenceField
-            id="positive-test-rate"
-            label={t('calculator.prevalence.positive_case_percentage')}
-            value={data.positiveCasePercentage.toString()}
+            value={
+              data.positiveCasePercentage
+                ? data.positiveCasePercentage.toString()
+                : ''
+            }
             unit="%"
             setter={(value) => {
               setter({ ...data, positiveCasePercentage: Number(value) })
@@ -395,60 +391,100 @@ export const PrevalenceControls: React.FunctionComponent<{
             inputType="number"
             max={100}
             min={0}
-            isEditable={isManualEntryCurrently}
             className="hide-number-buttons"
           />
-        )}
-        {!locationSet ? null : (
-          <>
-            <div>
-              <em>
-                <Trans>calculator.prevalence.data_last_updated</Trans>:{' '}
-                {PrevalenceDataDate}
-              </em>
-            </div>
-            <div>
-              <p className="mt-3">
-                <Trans i18nKey="calculator.prevalence_info_source_information">
-                  Prevalence data consolidated from {}
-                  <a
-                    href="https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Johns Hopkins CSSE
-                  </a>{' '}
-                  (reported cases), {}
-                  <a
-                    href="https://apidocs.covidactnow.org/"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Covid Act Now
-                  </a>{' '}
-                  (US positive test rates), {}
-                  <a
-                    href="https://ourworldindata.org/coronavirus-testing#testing-for-covid-19-background-the-our-world-in-data-covid-19-testing-dataset"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Our World in Data
-                  </a>{' '}
-                  (international positive test rates), and {}
-                  <a
-                    href="https://covid19.geo-spatial.org/despre"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Coronavirus COVID-19 România
-                  </a>{' '}
-                  (Romania reported cases).
-                </Trans>
-              </p>
-            </div>
-          </>
-        )}
-      </ControlledExpandable>
+        </div>
+      ) : (
+        <ControlledExpandable
+          id="prevalence-details"
+          header={t('calculator.prevalence.details_header')}
+          headerClassName={isManualEntryCurrently ? 'd-none' : ''}
+          open={detailsOpen}
+          setter={setDetailsOpen}
+        >
+          <PrevalenceResult data={data} />
+
+          <PrevalenceFieldStatic
+            id="reported-cases"
+            label={t('calculator.prevalence.last_week_cases')}
+            value={data.casesPastWeek || 0}
+          />
+          <PrevalenceFieldStatic
+            id="population"
+            label={t('calculator.prevalence.population')}
+            value={data.population}
+          />
+          {locationSet && data.casesIncreasingPercentage === 0 ? (
+            <div>{t('calculator.prevalence.cases_stable_or_decreasing')}</div>
+          ) : (
+            <PrevalenceFieldStatic
+              id="percent-increase"
+              label={t('calculator.prevalence.percent_increase_in_cases')}
+              value={data.casesIncreasingPercentage}
+              unit="%"
+            />
+          )}
+          <PrevalenceFieldStatic
+            id="positive-test-rate"
+            label={t('calculator.prevalence.positive_case_percentage')}
+            value={
+              data.positiveCasePercentage === null
+                ? 'no data available'
+                : data.positiveCasePercentage.toString()
+            }
+            unit="%"
+          />
+          {!locationSet ? null : (
+            <>
+              <div>
+                <em>
+                  <Trans>calculator.prevalence.data_last_updated</Trans>:{' '}
+                  {PrevalenceDataDate}
+                </em>
+              </div>
+              <div>
+                <p className="mt-3">
+                  <Trans i18nKey="calculator.prevalence_info_source_information">
+                    Prevalence data consolidated from {}
+                    <a
+                      href="https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Johns Hopkins CSSE
+                    </a>{' '}
+                    (reported cases), {}
+                    <a
+                      href="https://apidocs.covidactnow.org/"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Covid Act Now
+                    </a>{' '}
+                    (US positive test rates), {}
+                    <a
+                      href="https://ourworldindata.org/coronavirus-testing#testing-for-covid-19-background-the-our-world-in-data-covid-19-testing-dataset"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Our World in Data
+                    </a>{' '}
+                    (international positive test rates), and {}
+                    <a
+                      href="https://covid19.geo-spatial.org/despre"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Coronavirus COVID-19 România
+                    </a>{' '}
+                    (Romania reported cases).
+                  </Trans>
+                </p>
+              </div>
+            </>
+          )}
+        </ControlledExpandable>
+      )}
     </React.Fragment>
   )
 }

--- a/src/components/calculator/prevalence/LocationPrevalenceDetails.tsx
+++ b/src/components/calculator/prevalence/LocationPrevalenceDetails.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { PrevalenceResult } from './PrevalenceResult'
+import { ControlledExpandable } from 'components/Expandable'
+import { CalculatorData } from 'data/calculate'
+import { PrevalenceDataDate } from 'data/location'
+
+const PrevalenceFieldStatic: React.FunctionComponent<{
+  id: string
+  label: string
+  value: string | number
+  unit?: string
+}> = ({ id, label, value, unit }): React.ReactElement => {
+  return (
+    <div id={id}>
+      {label}: {typeof value === 'number' ? value.toLocaleString() : value}
+      {unit}
+    </div>
+  )
+}
+
+export const LocationPrevalenceDetails: React.FunctionComponent<{
+  id: string
+  header: string
+  open: boolean
+  setter: (value: boolean) => void
+  data: CalculatorData
+  locationSet: boolean
+  hide: boolean
+}> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <ControlledExpandable
+      id={props.id}
+      header={props.header}
+      headerClassName={props.hide ? 'd-none' : ''}
+      open={props.open}
+      setter={props.setter}
+    >
+      <PrevalenceResult data={props.data} />
+
+      <PrevalenceFieldStatic
+        id="reported-cases"
+        label={t('calculator.prevalence.last_week_cases')}
+        value={props.data.casesPastWeek || 0}
+      />
+      <PrevalenceFieldStatic
+        id="population"
+        label={t('calculator.prevalence.population')}
+        value={props.data.population}
+      />
+      {props.locationSet && props.data.casesIncreasingPercentage === 0 ? (
+        <div>{t('calculator.prevalence.cases_stable_or_decreasing')}</div>
+      ) : (
+        <PrevalenceFieldStatic
+          id="percent-increase"
+          label={t('calculator.prevalence.percent_increase_in_cases')}
+          value={props.data.casesIncreasingPercentage}
+          unit="%"
+        />
+      )}
+      <PrevalenceFieldStatic
+        id="positive-test-rate"
+        label={t('calculator.prevalence.positive_case_percentage')}
+        value={
+          props.data.positiveCasePercentage === null
+            ? 'no data available'
+            : props.data.positiveCasePercentage.toString()
+        }
+        unit="%"
+      />
+      {!props.locationSet ? null : (
+        <>
+          <div>
+            <em>
+              <Trans>calculator.prevalence.data_last_updated</Trans>:{' '}
+              {PrevalenceDataDate}
+            </em>
+          </div>
+          <div>
+            <p className="mt-3">
+              <Trans i18nKey="calculator.prevalence_info_source_information">
+                Prevalence data consolidated from {}
+                <a
+                  href="https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Johns Hopkins CSSE
+                </a>{' '}
+                (reported cases), {}
+                <a
+                  href="https://apidocs.covidactnow.org/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Covid Act Now
+                </a>{' '}
+                (US positive test rates), {}
+                <a
+                  href="https://ourworldindata.org/coronavirus-testing#testing-for-covid-19-background-the-our-world-in-data-covid-19-testing-dataset"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Our World in Data
+                </a>{' '}
+                (international positive test rates), and {}
+                <a
+                  href="https://covid19.geo-spatial.org/despre"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Coronavirus COVID-19 România
+                </a>{' '}
+                (Romania reported cases).
+              </Trans>
+            </p>
+          </div>
+        </>
+      )}
+    </ControlledExpandable>
+  )
+}
+
+export default LocationPrevalenceDetails

--- a/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
+++ b/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
@@ -1,0 +1,139 @@
+import { isNumber } from 'lodash'
+import React from 'react'
+import { Form, InputGroup } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { BsDash } from 'react-icons/bs'
+
+import { PrevalenceResult } from './PrevalenceResult'
+import { CalculatorData } from 'data/calculate'
+
+const PrevalenceField: React.FunctionComponent<{
+  id: string
+  label: string
+  value: string | number
+  unit?: string
+  setter: (newValue: string) => void
+  inputType: string
+  max?: number
+  min?: number
+  helpText?: string
+  className?: string
+}> = ({
+  id,
+  label,
+  value,
+  setter,
+  unit,
+  inputType,
+  max,
+  min,
+  helpText,
+  className,
+}): React.ReactElement => {
+  let body: React.ReactElement = (
+    <Form.Control
+      className={'form-control form-control-lg col-md-3 col-lg-6 ' + className}
+      type={inputType}
+      value={value}
+      readOnly={false}
+      onChange={(e) => {
+        if (isNumber(max) || isNumber(min)) {
+          let newValue = Number.parseFloat(e.target.value)
+          newValue = isNumber(max) && newValue > max ? max : newValue
+          newValue = isNumber(min) && newValue < min ? min : newValue
+          setter(newValue.toString())
+        } else {
+          setter(e.target.value)
+        }
+      }}
+    />
+  )
+  if (unit) {
+    body = (
+      <InputGroup className="mb-3">
+        {body}
+        <InputGroup.Append>
+          <InputGroup.Text>%</InputGroup.Text>
+        </InputGroup.Append>
+      </InputGroup>
+    )
+  }
+  return (
+    <Form.Group controlId={id} className="mb-3">
+      <Form.Label>{label}</Form.Label>
+      {body}
+      {helpText && (
+        <Form.Text id={id + 'HelpText'} muted>
+          {helpText}
+        </Form.Text>
+      )}
+    </Form.Group>
+  )
+}
+
+export const ManualPrevalenceDetails: React.FunctionComponent<{
+  id: string
+  data: CalculatorData
+  setter: (newData: CalculatorData) => void
+}> = (props): React.ReactElement => {
+  const { t } = useTranslation()
+  return (
+    <div id={props.id}>
+      <span className="details-header">
+        <BsDash /> {t('calculator.prevalence.details_header')}
+      </span>
+      <PrevalenceResult data={props.data} />
+      <PrevalenceField
+        id="reported-cases"
+        label={t('calculator.prevalence.last_week_cases')}
+        value={props.data.casesPastWeek || 0}
+        setter={(value) =>
+          props.setter({ ...props.data, casesPastWeek: parseInt(value || '') })
+        }
+        inputType="number"
+        className="hide-number-buttons"
+      />
+      <PrevalenceField
+        id="population"
+        label={t('calculator.prevalence.population')}
+        value={props.data.population}
+        setter={(value) => props.setter({ ...props.data, population: value })}
+        inputType="text"
+        className="hide-number-buttons"
+      />
+      <PrevalenceField
+        id="percent-increase"
+        label={t('calculator.prevalence.percent_increase_in_cases')}
+        value={props.data.casesIncreasingPercentage}
+        unit="%"
+        setter={(value) => {
+          props.setter({
+            ...props.data,
+            casesIncreasingPercentage: Number(value),
+          })
+        }}
+        inputType="number"
+        min={0}
+        className="hide-number-buttons"
+      />
+      <PrevalenceField
+        id="positive-test-rate"
+        label={t('calculator.prevalence.positive_case_percentage')}
+        value={
+          props.data.positiveCasePercentage
+            ? props.data.positiveCasePercentage.toString()
+            : ''
+        }
+        unit="%"
+        setter={(value) => {
+          props.setter({ ...props.data, positiveCasePercentage: Number(value) })
+        }}
+        inputType="number"
+        max={100}
+        min={0}
+        className="hide-number-buttons"
+      />
+    </div>
+  )
+}
+export default ManualPrevalenceDetails

--- a/src/components/calculator/prevalence/PrevalenceResult.tsx
+++ b/src/components/calculator/prevalence/PrevalenceResult.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Card } from 'react-bootstrap'
+import { Trans } from 'react-i18next'
+
+import {
+  CalculatorData,
+  calculateLocationPersonAverage,
+  calculateLocationReportedPrevalence,
+} from 'data/calculate'
+
+export const PrevalenceResult = (props: {
+  data: CalculatorData
+}): React.ReactElement => {
+  return (
+    <Card className="prevalence-result">
+      <Card.Body>
+        <div>
+          <Trans>calculator.prevalence.reported_prevalence</Trans>:{' '}
+          {(
+            (calculateLocationReportedPrevalence(props.data) || 0) * 100
+          ).toFixed(2)}
+          %
+        </div>
+        <div>
+          <strong>
+            <Trans>calculator.prevalence.adjusted_prevalence</Trans>:{' '}
+            {(
+              ((calculateLocationPersonAverage(props.data) || 0) * 100) /
+              1e6
+            ).toFixed(2)}
+            %
+          </strong>
+        </div>
+      </Card.Body>
+    </Card>
+  )
+}
+
+export default PrevalenceResult

--- a/src/components/calculator/styles/PrevalenceControls.scss
+++ b/src/components/calculator/styles/PrevalenceControls.scss
@@ -11,7 +11,20 @@
   }
 }
 
-button#switchBetweenManualDataAndLocationSelection {
+#switchBetweenManualDataAndLocationSelection {
   margin-bottom: 15px;
 }
 
+#switchBetweenManualDataAndLocationSelectionText {
+  margin-left: 0.5em;
+}
+
+.rbt-input-main:disabled {
+  color: $gray-500 !important;
+}
+
+#details-header {
+  font-weight: bold;
+  display: block;
+  padding-bottom: 0.5em;
+}

--- a/src/components/calculator/styles/PrevalenceControls.scss
+++ b/src/components/calculator/styles/PrevalenceControls.scss
@@ -23,7 +23,7 @@
   color: $gray-500 !important;
 }
 
-#details-header {
+.details-header {
   font-weight: bold;
   display: block;
   padding-bottom: 0.5em;

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -32,6 +32,7 @@ const dateAfterDay0 = (daysAfterDay0: number) => {
 // Prevailance is PREVALENCE (2x prevalance ratio)
 const baseTestData = {
   riskBudget: BUDGET_ONE_PERCENT,
+  useManualEntry: 0,
   subLocation: 'mock city',
   topLocation: 'mock state',
   population: '1,000,000',

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -23,6 +23,7 @@ export interface CalculatorData {
   riskBudget: number
 
   // Prevalence
+  useManualEntry: number
   topLocation: string
   subLocation: string
   population: string
@@ -49,6 +50,7 @@ export interface CalculatorData {
 export const defaultValues: CalculatorData = {
   riskBudget: BUDGET_ONE_PERCENT,
 
+  useManualEntry: 0,
   topLocation: '',
   subLocation: '',
   population: '',
@@ -82,7 +84,7 @@ export const DAY_0 = new Date(2020, 1, 12)
 const MS_PER_DAY = 1000 * 60 * 60 * 24
 
 // From https://covid19-projections.com/estimating-true-infections-revisited/
-const prevalanceRatio = (positivityPercent: number | null, date: Date) => {
+const prevalenceRatio = (positivityPercent: number | null, date: Date) => {
   const day_i = (date.getTime() - DAY_0.getTime()) / MS_PER_DAY
   if (positivityPercent === null || positivityPercent > 100) {
     // No positivity data, assume the worst.
@@ -150,7 +152,7 @@ export const calculateLocationReportedPrevalence = (
     }
 
     const lastWeek = data.casesPastWeek
-    if (lastWeek === 0 && data.topLocation === '') {
+    if (data.useManualEntry && lastWeek === 0) {
       // If the data say zero cases, go with it; but if the user
       // entered zero cases, call it incomplete.
       return null
@@ -175,7 +177,7 @@ export const calculateLocationPersonAverage = (
   }
 
   try {
-    const underreportingFactor = prevalanceRatio(
+    const underreportingFactor = prevalenceRatio(
       data.positiveCasePercentage,
       data.prevalanceDataDate,
     )

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -29,8 +29,6 @@ const formValue = function (label: string, multiplier: number): FormValue {
   return { label, multiplier }
 }
 
-export const TOP_LOCATION_MANUAL_ENTRY = 'MANUAL_DATA'
-
 export const B117_CONTAGIOUSNESS_ADJUSTMENT = 1.5
 
 export const oneTimeMult = 0.06 * B117_CONTAGIOUSNESS_ADJUSTMENT

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -5,6 +5,7 @@ import { CalculatorData } from './calculate'
 export type PartialData = Omit<
   CalculatorData,
   | 'riskBudget'
+  | 'useManualEntry'
   | 'topLocation'
   | 'subLocation'
   | 'population'

--- a/src/data/queryParams.ts
+++ b/src/data/queryParams.ts
@@ -3,11 +3,11 @@ import { QueryParamConfigMap } from 'serialize-query-params'
 import { NumberParam, StringParam } from 'use-query-params'
 
 import { CalculatorData, QueryData, defaultValues } from './calculate'
-import { TOP_LOCATION_MANUAL_ENTRY } from './data'
 
 export const queryConfig: QueryParamConfigMap = {
   riskBudget: NumberParam,
 
+  useManualEntry: NumberParam,
   topLocation: StringParam,
   subLocation: StringParam,
   population: StringParam,
@@ -33,7 +33,7 @@ export const filterParams = (data: CalculatorData): QueryData => {
     return k in queryConfig && v !== defaultValues[fk]
   })
 
-  if (filtered.topLocation !== TOP_LOCATION_MANUAL_ENTRY) {
+  if (data.useManualEntry === 0) {
     // Remove data that will be fetched if location is set.
     delete filtered.population
     delete filtered.casesPastWeek

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -123,8 +123,7 @@
     "select_location_label": "Country or US State",
     "select_location_placeholder": "Select Country or US State...",
     "switch_button": {
-      "select_location": "Switch to pre-populated location data",
-      "enter_data_manually": "Switch to manual data entry mode"
+      "enter_data_manually": "Override location-based data"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), <7>Our World in Data</7> (international positive test rates), and <10>Coronavirus COVID-19 România</10> (Romania reported cases).",
     "select_scenario": "Search for an activity or build your own below...",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -123,9 +123,11 @@ export const Calculator = (): React.ReactElement => {
     return { points: expectedValue, lowerBound, upperBound }
   }, [calculatorData, setQuery])
 
+  // Location mode and not blank OR fully valid manual mode
   const prevalenceIsFilled =
-    calculatorData.topLocation !== '' ||
-    (parsePopulation(calculatorData.population) > 0 &&
+    (!calculatorData.useManualEntry && calculatorData.topLocation !== '') ||
+    (calculatorData.useManualEntry &&
+      parsePopulation(calculatorData.population) > 0 &&
       calculatorData.casesPastWeek > 0 &&
       calculatorData.casesIncreasingPercentage >= 0 &&
       calculatorData.positiveCasePercentage !== null &&

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -107,13 +107,19 @@ export const Calculator = (): React.ReactElement => {
       recordCalculatorChanged(expectedValue)
     }
 
+    const getStringForLocalStorage = (incomingData: CalculatorData) => {
+      const data: Partial<CalculatorData> = {
+        ...incomingData,
+        persistedAt: Date.now(),
+      }
+      delete data['prevalanceDataDate']
+      return JSON.stringify(data)
+    }
+
     // Store data for refresh
     localStorage.setItem(
       FORM_STATE_KEY,
-      JSON.stringify({
-        ...calculatorData,
-        persistedAt: Date.now(),
-      }),
+      getStringForLocalStorage(calculatorData),
     )
 
     setQuery(filterParams(calculatorData), 'replace')
@@ -123,7 +129,6 @@ export const Calculator = (): React.ReactElement => {
     return { points: expectedValue, lowerBound, upperBound }
   }, [calculatorData, setQuery])
 
-  // Location mode and not blank OR fully valid manual mode
   const prevalenceIsFilled =
     (!calculatorData.useManualEntry && calculatorData.topLocation !== '') ||
     (calculatorData.useManualEntry &&


### PR DESCRIPTION
* when toggling data entry mode, keep country/state/county information
  but mark it as disabled
  * previously, the button would jump away from user's cursor position,
    causing some confusion. Now it stays still.
  * previously, hitting the manual data entry button would clear
    existing location data. This isn't ideal for someone exploring the
    interface by clicking on everything.