### PR TITLE
Cleanup front page intro text

### DIFF
--- a/src/components/calculator/FirstTimeUserIntroduction.tsx
+++ b/src/components/calculator/FirstTimeUserIntroduction.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { Alert } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
-import { BsCheckBox } from 'react-icons/bs'
 
 import { Expandable } from 'components/Expandable'
 
@@ -12,6 +10,7 @@ export function FirstTimeUserIntroduction(): React.ReactElement {
       <Expandable
         id="first-time-user-introduction"
         header={t('calculator.firsttime.microcovid_header')}
+        open={true}
       >
         <Trans>calculator.firsttime.microcovid_explanation</Trans>
       </Expandable>
@@ -26,20 +25,6 @@ export function FirstTimeUserIntroduction(): React.ReactElement {
           </Trans>
         </p>
       </Expandable>
-      <Alert variant="secondary">
-        <BsCheckBox />{' '}
-        <Trans i18nKey="calculator.alerts.survey_request">
-          <strong>We would love your feedback:</strong> lipsum
-          <a
-            href="https://forms.gle/WzFWcmyXwQMNRqGa7"
-            target="_blank"
-            rel="noreferrer"
-          >
-            survey
-          </a>{' '}
-          lipsum
-        </Trans>
-      </Alert>
     </>
   )
 }

--- a/src/components/calculator/FirstTimeUserIntroduction.tsx
+++ b/src/components/calculator/FirstTimeUserIntroduction.tsx
@@ -10,7 +10,6 @@ export function FirstTimeUserIntroduction(): React.ReactElement {
       <Expandable
         id="first-time-user-introduction"
         header={t('calculator.firsttime.microcovid_header')}
-        open={true}
       >
         <Trans>calculator.firsttime.microcovid_explanation</Trans>
       </Expandable>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,16 +135,18 @@
     "risk_modifier_multiple": "{{multiplier}}x the risk",
     "firsttime": {
       "microcovid_header": "What is a microCOVID?",
-      "microcovid_explanation": "<p>The calculator introduces a new concept, the microCOVID. One microCOVID is a one-in-a-million chance of getting COVID.</p> <p>An activity that’s 20,000 microCOVIDs is very unsafe, as you have a 2% risk of getting COVID <em>every time you do it</em>. An activity that’s 20 microCOVIDs is relatively safe, as you could do it every week for a year and still have only about a 0.1% chance of getting COVID.</p>",
-      "budget_header": "How can I manage my risk using a risk budget?",
-      "budget_explanation": "We decided an annual risk budget of a 1% chance of catching COVID per year was reasonable for most healthy people who are not in contact with vulnerable groups. To learn how we arrived at that number, <1>click here</1>. If you want to follow this 1%-risk-per-year budget, you’ll want your weekly budget of activities to sum to less than about 200 microCOVIDs each week. We’ve created a handy <3>Risk Tracker</3> that lets you keep track of your activities over time."
+      "microcovid_explanation": "<p>We created the concept of the \"microcovid\" as a new quantitative unit for risk. One microCOVID is a one-in-a-million chance of getting COVID.</p> <p>An activity that’s 20,000 microCOVIDs means that you have a 2% risk of getting COVID <em>every time you do it</em>. An activity that’s 20 microCOVIDs (or 0.00002%) is relatively safe, as you could do it <em>every week for a year</em> and still have only accumulated about a 0.1% chance of getting COVID.</p>",
+      "budget_header": "What is a risk budget?",
+      "budget_explanation": "<p>You may decide that you're comfortable with taking on a certain amount of COVID risk. You can think about this amount of risk that you're willing to take on as a \"risk budget\".</p> <p>For most healthy people who are not in contact with vulnerable groups, we think an annual risk budget of a <strong>1% chance of catching COVID</strong> is reasonable - that's a budget of 10,000 microCOVIDs a year. In order to meet this budget, you'd need to stick to a maximum of about <strong>200 microCOVIDs a week</strong>.</p>"
     },
     "risk_tolerance_1_percent_label": "Standard Caution Budget",
     "risk_tolerance_1_percent_explanation": "Budget: 1% chance of COVID per year (200 microCOVIDs per week) (suggested for healthy people NOT in close contact with more vulnerable people)",
     "risk_tolerance_point1_percent_label": "High Caution Budget",
     "risk_tolerance_point1_percent_explanation": "Budget: 0.1% chance of COVID per year (20 microCOVIDs per week) (suggested if you or your close contacts are more vulnerable to COVID)",
     "intro": {
+      "whats_this2": "This calculator lets you estimate COVID risk and find effective safety measures for customizable situations. Examples: how risky is <1>a trip to my grocery store</1>? What's the safest way to <3>see a friend</3>? How much would it help to <5>wear a better mask at my workplace</5>?",
       "whats_this": "We’ve constructed a calculator that lets you estimate the risk of getting COVID from an activity or relationship in your daily life, using the <1>best research available</1>. We hope this tool will help hone your intuition, lower your stress levels, and figure out good harm-reduction strategies.</p><p>The first step in protecting your family and community is to avoid getting COVID yourself.",
+      "see_video": "If you'd like to watch a video walkthrough of how to use the calculator, click <1>here</1>.",
       "call_to_action": "Calculate the approximate COVID risk of an activity or relationship"
     },
     "risk_step_label": "Step 2: Describe the activity or relationship",
@@ -152,10 +154,10 @@
     "risk_group_empty_warning": "First, enter your location",
     "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
     "alerts": {
-      "masks_update": "<0>January 26th, 2021:</0> We created new mask categories, and updated multipliers for mask types. Read more on <3>our new blog post about masks</3>.",
-      "b117": "<0>January 7th, 2021:</0> We've adjusted the model parameters for the new COVID-19 variant, B117. Read more <3>here</3>.",
-      "survey_request": "<0>We would love your feedback:</0> We want your help to make the microCOVID calculator as helpful as possible! <2>Please fill out our user survey</2> to help us prioritize new features.",
-      "full_changelog": "full changelog..."
+      "masks_update": "<0>January 28th, 2021:</0> We added new mask types, and updated multipliers for existing ones. Learn more in <3>our new blog post about masks</3>.",
+      "b117": "<0>January 5th, 2021:</0> The calculator now accounts for the new more infectious COVID-19 variant B117. Read more <3>here</3>.",
+      "survey_request": "<0>We would love your feedback:</0> Please fill out <2>our user survey</2> to help us make the calculator as helpful as possible, and prioritize new features.",
+      "full_changelog": "see all updates..."
     }
   },
   "per week": "per week",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -153,6 +153,7 @@
     "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
     "alerts": {
       "masks_update": "<0>Model update:</0> Our mask options have been expanded and updated. For more details, see the Masks section of the <3>White Paper</3>.",
+      "b117": "<0>Model update:</0> We've adjusted parameters for the new COVID-19 variant, B117. Read more <3>here</3>.",
       "survey_request": "<0>We would love your feedback:</0> We want your help to make the microCOVID calculator as helpful as possible! <2>Please fill out our user survey</2> to help us prioritize new features."
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -152,9 +152,10 @@
     "risk_group_empty_warning": "First, enter your location",
     "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
     "alerts": {
-      "masks_update": "<0>Model update:</0> Our mask options have been expanded and updated. For more details, see the Masks section of the <3>White Paper</3>.",
-      "b117": "<0>Model update:</0> We've adjusted parameters for the new COVID-19 variant, B117. Read more <3>here</3>.",
-      "survey_request": "<0>We would love your feedback:</0> We want your help to make the microCOVID calculator as helpful as possible! <2>Please fill out our user survey</2> to help us prioritize new features."
+      "masks_update": "<0>January 26th, 2021:</0> We created new mask categories, and updated multipliers for mask types. Read more on <3>our new blog post about masks</3>.",
+      "b117": "<0>January 7th, 2021:</0> We've adjusted the model parameters for the new COVID-19 variant, B117. Read more <3>here</3>.",
+      "survey_request": "<0>We would love your feedback:</0> We want your help to make the microCOVID calculator as helpful as possible! <2>Please fill out our user survey</2> to help us prioritize new features.",
+      "full_changelog": "full changelog..."
     }
   },
   "per week": "per week",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -165,7 +165,7 @@ export const Calculator = (): React.ReactElement => {
           <FirstTimeUserIntroduction />
         </Col>
         <Col lg="4" md="12">
-          <Alert variant="secondary">
+          <Alert variant="info">
             <BsCheckBox />{' '}
             <Trans i18nKey="calculator.alerts.survey_request">
               <strong>We would love your feedback:</strong> lipsum
@@ -179,7 +179,7 @@ export const Calculator = (): React.ReactElement => {
               lipsum
             </Trans>
           </Alert>
-          <Alert className="alert-info">
+          <Alert variant="secondary">
             <BsFillInfoCircleFill />{' '}
             <Trans i18nKey="calculator.alerts.masks_update">
               <strong>Model update:</strong> Lipsum{' '}

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -158,11 +158,25 @@ export const Calculator = (): React.ReactElement => {
       <Row>
         <Col md="12" lg="8" id="calculator-introduction">
           <p>
-            <Trans i18nKey="calculator.intro.whats_this">
-              Lorem ipsum <a href="/paper">whitepaper</a> dolor sic amet...
+            <Trans i18nKey="calculator.intro.whats_this2">
+              Lorem ipsum dolor sic amet...
+              <span>grocery store</span>,<span>see a specific person</span>,
+              <span>work precautions</span>,
             </Trans>
           </p>
           <FirstTimeUserIntroduction />
+          <p>
+            <Trans i18nKey="calculator.intro.see_video">
+              Lorem ipsum dolor sic amet...
+              <a
+                href="https://www.youtube.com/watch?v=5-ybfrEk1CI"
+                target="_blank"
+                rel="noreferrer"
+              >
+                here
+              </a>
+            </Trans>
+          </p>
         </Col>
         <Col lg="4" md="12">
           <Alert className="request-feedback" variant="primary">

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -3,7 +3,7 @@ import { stringify } from 'query-string'
 import React, { useEffect, useMemo, useState } from 'react'
 import { Alert, Col, Row } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
-import { BsFillInfoCircleFill, BsLink45Deg } from 'react-icons/bs'
+import { BsCheckBox, BsFillInfoCircleFill, BsLink45Deg } from 'react-icons/bs'
 import { Link } from 'react-router-dom'
 import { encodeQueryParams, useQueryParams } from 'use-query-params'
 import 'pages/styles/Calculator.scss'
@@ -157,13 +157,6 @@ export const Calculator = (): React.ReactElement => {
     <div id="calculator">
       <Row>
         <Col md="12" lg="8" id="calculator-introduction">
-          <Alert className="alert-info">
-            <BsFillInfoCircleFill />{' '}
-            <Trans i18nKey="calculator.alerts.masks_update">
-              <strong>Model update:</strong> Lipsum{' '}
-              <Link to="/paper/14-research-sources#masks">White Paper</Link>.
-            </Trans>
-          </Alert>
           <p>
             <Trans i18nKey="calculator.intro.whats_this">
               Lorem ipsum <a href="/paper">whitepaper</a> dolor sic amet...
@@ -171,7 +164,29 @@ export const Calculator = (): React.ReactElement => {
           </p>
           <FirstTimeUserIntroduction />
         </Col>
-        <Col lg="4" md="12" className="d-none d-lg-block"></Col>
+        <Col lg="4" md="12">
+          <Alert variant="secondary">
+            <BsCheckBox />{' '}
+            <Trans i18nKey="calculator.alerts.survey_request">
+              <strong>We would love your feedback:</strong> lipsum
+              <a
+                href="https://forms.gle/WzFWcmyXwQMNRqGa7"
+                target="_blank"
+                rel="noreferrer"
+              >
+                survey
+              </a>{' '}
+              lipsum
+            </Trans>
+          </Alert>
+          <Alert className="alert-info">
+            <BsFillInfoCircleFill />{' '}
+            <Trans i18nKey="calculator.alerts.masks_update">
+              <strong>Model update:</strong> Lipsum{' '}
+              <Link to="/paper/14-research-sources#masks">White Paper</Link>.
+            </Trans>
+          </Alert>
+        </Col>
       </Row>
       <Row>
         <Col>

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -3,7 +3,7 @@ import { stringify } from 'query-string'
 import React, { useEffect, useMemo, useState } from 'react'
 import { Alert, Col, Row } from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
-import { BsCheckBox, BsFillInfoCircleFill, BsLink45Deg } from 'react-icons/bs'
+import { BsLink45Deg } from 'react-icons/bs'
 import { Link } from 'react-router-dom'
 import { encodeQueryParams, useQueryParams } from 'use-query-params'
 import 'pages/styles/Calculator.scss'
@@ -165,8 +165,7 @@ export const Calculator = (): React.ReactElement => {
           <FirstTimeUserIntroduction />
         </Col>
         <Col lg="4" md="12">
-          <Alert variant="info">
-            <BsCheckBox />{' '}
+          <Alert className="request-feedback" variant="primary">
             <Trans i18nKey="calculator.alerts.survey_request">
               <strong>We would love your feedback:</strong> lipsum
               <a
@@ -179,13 +178,21 @@ export const Calculator = (): React.ReactElement => {
               lipsum
             </Trans>
           </Alert>
-          <Alert variant="secondary">
-            <BsFillInfoCircleFill />{' '}
+          <Alert className="changelog" variant="light">
             <Trans i18nKey="calculator.alerts.masks_update">
               <strong>Model update:</strong> Lipsum{' '}
-              <Link to="/paper/14-research-sources#masks">White Paper</Link>.
+              <Link to="/blog/masks">our new blog post about masks</Link>.
             </Trans>
           </Alert>
+          <Alert className="changelog" variant="light">
+            <Trans i18nKey="calculator.alerts.b117">
+              <strong>Model update:</strong> Lipsum{' '}
+              <Link to="/blog/b117">White Paper</Link>.
+            </Trans>
+          </Alert>
+          <Link id="full-changelog" to="/paper/changelog">
+            {t('calculator.alerts.full_changelog')}
+          </Link>
         </Col>
       </Row>
       <Row>

--- a/src/pages/__tests__/Calculator.test.tsx
+++ b/src/pages/__tests__/Calculator.test.tsx
@@ -8,7 +8,7 @@ describe('calculator page', () => {
   it('renders at all', () => {
     const { getByText } = render(<Calculator />, { wrapper: AllProviders })
 
-    expect(getByText(/constructed a calculator that lets/i)).toBeInTheDocument()
+    expect(getByText(/new quantitative unit for risk/i)).toBeInTheDocument()
   })
 
   it('activity details section reveals after location is selected', () => {

--- a/src/pages/styles/Calculator.scss
+++ b/src/pages/styles/Calculator.scss
@@ -13,6 +13,30 @@
 
   }
 
+  .request-feedback {
+    border: none;
+  }
+
+  .changelog {
+    background-color: $white !important;
+    border: none;
+    margin-bottom: 0;
+    padding: 0;
+    padding-bottom: 1.25em;
+  }
+
+  #full-changelog {
+    font-style: italic;
+    color: $secondary;
+    text-decoration: none;
+    padding: 0;
+  }
+
+  #full-changelog:hover {
+    color: $primary;
+    text-decoration: underline;
+  }
+
   .col-md-12 {
     margin-bottom: 30px;
   }


### PR DESCRIPTION
Based on user testing feedback:

> UX Interview observation: Users were frequently derailed by the "Model Update" box at the top of the page. One of them said she didn't know what it meant, so she assumed the site wasn't for people like her. Another one did know what it meant but still saw it as being so technically detailed that she assumed the site wasn't for her.
> Could we consider moving updates and non-essential information to a sidebar? (several users also mentioned the conspicuously empty space on the right side of the page)

This is my first take on it. @octern is going to draft up something that he put more thought into and we can use the PR to implement whatever he/we comes up with.