### PR TITLE
Always show scenario selector

### DIFF
--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -1,12 +1,45 @@
 import i18n from 'i18n'
 import React from 'react'
-import { Form, InputGroup } from 'react-bootstrap'
+import { Button, Form, InputGroup } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import { useTranslation } from 'react-i18next'
 import { BsSearch } from 'react-icons/bs'
 
 import { CalculatorData } from 'data/calculate'
 import { PartialData, prepopulated } from 'data/prepopulated'
+
+export const SavedDataLink: React.FunctionComponent<{
+  currentData: CalculatorData
+  setter: (newData: CalculatorData) => void
+  scenarioName: string
+  scenarioNameSetter: (newScenario: string) => void
+}> = (props): React.ReactElement => {
+  const setSavedData = (key: string): void => {
+    let foundData: PartialData | CalculatorData | null = null
+    foundData = prepopulated[key]
+
+    if (foundData) {
+      props.setter({
+        ...props.currentData,
+        ...foundData,
+      })
+    }
+    props.scenarioNameSetter(key)
+  }
+
+  return (
+    <Button
+      variant="link"
+      className="p-0 m-0 border-0"
+      onClick={() => {
+        setSavedData(props.scenarioName)
+        props.scenarioNameSetter(props.scenarioName)
+      }}
+    >
+      {props.children}
+    </Button>
+  )
+}
 
 export const SavedDataSelector: React.FunctionComponent<{
   currentData: CalculatorData

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -1,3 +1,4 @@
+import i18n from 'i18n'
 import React from 'react'
 import { Form, InputGroup } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
@@ -19,8 +20,7 @@ export const SavedDataSelector: React.FunctionComponent<{
 
   let selected: string[] = []
   if (props.scenarioName !== undefined && props.scenarioName !== '') {
-    const selectedOption = props.scenarioName + ' '
-    prepopulatedOptions.push(selectedOption) // Create a fake option so the selected option still appears in the dropdown
+    const selectedOption = props.scenarioName
     selected = [selectedOption]
   }
 
@@ -37,6 +37,22 @@ export const SavedDataSelector: React.FunctionComponent<{
     props.scenarioNameSetter(key)
   }
 
+  const filterByCallback = (
+    option: string,
+    props: { text: string; selected: string[] },
+  ) => {
+    const propsText: string = props.text || ''
+
+    // User is considering switching scenarios. Show all options.
+    if (props.selected.length > 0) {
+      return true
+    }
+    if (option === i18n.t('scenario.custom')) {
+      return true
+    }
+    return option.toLowerCase().indexOf(propsText.toLowerCase()) !== -1
+  }
+
   return (
     <Form.Group>
       <InputGroup>
@@ -47,11 +63,22 @@ export const SavedDataSelector: React.FunctionComponent<{
         </InputGroup.Prepend>
         <Typeahead
           clearButton={true}
+          filterBy={filterByCallback}
           emptyLabel={t('calculator.no_prebuilt_scenario_found')}
-          multiple
           highlightOnlyResult={true}
           id="predefined-typeahead"
-          inputProps={{ autoComplete: 'chrome-off' }}
+          inputProps={{
+            autoComplete: 'chrome-off',
+            shouldSelectHint: (shouldSelect: boolean, event) => {
+              if (
+                event.keyCode === 13 /* return */ ||
+                event.keyCode === 9 /* tab */
+              ) {
+                return true
+              }
+              return shouldSelect
+            },
+          }}
           onChange={(e: string[]) => {
             if (e.length === 0) {
               setSavedData('')

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -42,17 +42,17 @@ export const Interaction: { [key: string]: FormValue } = {
     }),
     multiplier: oneTimeMult,
   },
-  repeated: {
-    label: i18n.t('data.repeated', {
-      percentage: fixedPointPrecisionPercent(housemateMult),
-    }),
-    multiplier: housemateMult,
-  },
   partner: {
     label: i18n.t('data.partner', {
       percentage: fixedPointPrecisionPercent(partnerMult),
     }),
     multiplier: partnerMult,
+  },
+  repeated: {
+    label: i18n.t('data.repeated', {
+      percentage: fixedPointPrecisionPercent(housemateMult),
+    }),
+    multiplier: housemateMult,
   },
 }
 

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -255,4 +255,18 @@ export const prepopulated: {
     yourMask: 'basic',
     voice: 'silent',
   },
+  [i18n.t('scenario.custom')]: {
+    // profile is ignored. Fill with anything.
+    riskProfile: '',
+    interaction: '',
+    personCount: 0,
+    symptomsChecked: 'no',
+
+    setting: '',
+    distance: '',
+    duration: 0,
+    theirMask: '',
+    yourMask: '',
+    voice: '',
+  },
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -150,9 +150,14 @@
       "call_to_action": "Calculate the approximate COVID risk of an activity or relationship"
     },
     "risk_step_label": "Step 2: Describe the scenario",
-    "type_of_interaction": "Is this a specific activity or an ongoing relationship?",
-    "risk_group_empty_warning": "First, enter your location",
-    "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
+    "type_of_interaction": "What are you trying to learn?",
+    "one_time_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per hour</1>.",
+    "repeated_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
+    "partner_interaction_risk_message": "If this person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
+    "whats_next_interaction_risk_message": "How likely is it someone is infected? It depends on location and the choices of the people around you. This calculator will walk you through <1>choices and factors that make the biggest difference</1> (backed by <4>research</4>!)",
+    "risk_group_empty_warning": "Enter your location first.",
+    "saved_scenario_loaded_message": "You chose a preset. <strong>Adjust these answers</strong> if they do not match the situation you have in mind.",
+    "custom_scenario_message": "You are building your own scenario. <strong>Fill out the calculator</strong> to learn how risky it is.",
     "alerts": {
       "masks_update": "<0>January 28th, 2021:</0> We added new mask types, and updated multipliers for existing ones. Learn more in <3>our new blog post about masks</3>.",
       "b117": "<0>January 5th, 2021:</0> The calculator now accounts for the new more infectious COVID-19 variant B117. Read more <3>here</3>.",
@@ -167,9 +172,9 @@
     "select_default_action": "Select one..."
   },
   "data": {
-    "oneTime": "One-time interaction or repeated activity [{{ percentage }} chance of transmission per hour]",
-    "repeated": "Household member, or visitor staying at your home [{{ percentage }} chance of transmission per week]",
-    "partner": "Partner / spouse [{{ percentage }} chance of transmission per week]",
+    "oneTime": "How risky is this social gathering/activity/workplace?",
+    "partner": "How risky is it to live/stay with a partner/spouse?",
+    "repeated": "How risky is it to live/stay with others (like roommates or family)?",
     "indoor": "Indoor",
     "filtered": "Indoors with a HEPA filter (flow rate 5x room size)",
     "transit": "A train with air filtration",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,7 @@
       "enter_data_manually": "Override location-based data"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), <7>Our World in Data</7> (international positive test rates), and <10>Coronavirus COVID-19 România</10> (Romania reported cases).",
-    "select_scenario": "Search for an activity or build your own below...",
+    "select_scenario": "Search for a scenario or build your own below...",
     "no_prebuilt_scenario_found": "We don't have this scenario yet, but you can build your own below.",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
@@ -149,7 +149,7 @@
       "see_video": "If you'd like to watch a video walkthrough of how to use the calculator, click <1>here</1>.",
       "call_to_action": "Calculate the approximate COVID risk of an activity or relationship"
     },
-    "risk_step_label": "Step 2: Describe the activity or relationship",
+    "risk_step_label": "Step 2: Describe the scenario",
     "type_of_interaction": "Is this a specific activity or an ongoing relationship?",
     "risk_group_empty_warning": "First, enter your location",
     "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,6 +214,7 @@
     }
   },
   "scenario": {
+    "custom": "Build your own custom scenario",
     "outdoorMasked2": "Outdoor masked hangout with 2 other people",
     "indoorUnmasked2": "Indoor unmasked hangout with 2 other people",
     "1person_15minCarRide": "Car ride with 1 other person for 15 mins",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -22,6 +22,7 @@ import {
   SavedDataLink,
   SavedDataSelector,
 } from 'components/calculator/SavedDataSelector'
+import { fixedPointPrecisionPercent } from 'components/calculator/util/FormatPrecision'
 import { Card } from 'components/Card'
 import {
   CalculatorData,
@@ -161,6 +162,25 @@ export const Calculator = (): React.ReactElement => {
 
   const { t } = useTranslation()
 
+  const SavedScenarioMessage: React.FunctionComponent<{
+    scenarioName: string
+  }> = (props): React.ReactElement => {
+    if (props.scenarioName === t('scenario.custom')) {
+      return (
+        <Alert variant="info">
+          <Trans>calculator.custom_scenario_message</Trans>
+        </Alert>
+      )
+    } else {
+      return (
+        <Alert variant="info">
+          <Trans values={{ scenarioName: scenarioName }}>
+            calculator.saved_scenario_loaded_message
+          </Trans>
+        </Alert>
+      )
+    }
+  }
   return (
     <div id="calculator">
       <Row>
@@ -266,11 +286,7 @@ export const Calculator = (): React.ReactElement => {
               </Col>
             </Row>
             {!scenarioName ? null : (
-              <Alert variant="info">
-                <Trans values={{ scenarioName: scenarioName }}>
-                  calculator.saved_scenario_loaded_message
-                </Trans>
-              </Alert>
+              <SavedScenarioMessage scenarioName={scenarioName} />
             )}
             <div>
               <GenericSelectControl
@@ -289,6 +305,59 @@ export const Calculator = (): React.ReactElement => {
                 source={Interaction}
                 hideRisk={true}
               />
+              {calculatorData.interaction === 'oneTime' ? (
+                <Alert variant="info">
+                  <Trans
+                    i18nKey="calculator.one_time_interaction_risk_message"
+                    values={{
+                      percentage: fixedPointPrecisionPercent(
+                        Interaction['oneTime'].multiplier,
+                      ),
+                    }}
+                  >
+                    Lorem ipsum <strong>dolor</strong> sit
+                  </Trans>
+                </Alert>
+              ) : null}
+              {calculatorData.interaction === 'repeated' ? (
+                <Alert variant="info">
+                  <Trans
+                    i18nKey="calculator.repeated_interaction_risk_message"
+                    values={{
+                      percentage: fixedPointPrecisionPercent(
+                        Interaction[calculatorData.interaction].multiplier,
+                      ),
+                    }}
+                  >
+                    Lorem ipsum <strong>dolor</strong>
+                  </Trans>
+                </Alert>
+              ) : null}
+              {calculatorData.interaction === 'partner' ? (
+                <Alert variant="info">
+                  <Trans
+                    i18nKey="calculator.partner_interaction_risk_message"
+                    values={{
+                      percentage: fixedPointPrecisionPercent(
+                        Interaction[calculatorData.interaction].multiplier,
+                      ),
+                    }}
+                  >
+                    Lorem ipsum <strong>dolor</strong>
+                  </Trans>
+                </Alert>
+              ) : null}
+              {calculatorData.interaction !== undefined &&
+              calculatorData.interaction !== '' ? (
+                <p>
+                  <Trans i18nKey="calculator.whats_next_interaction_risk_message">
+                    Lorem ipsum dolor <strong>sit amet</strong>
+                    (backed by{' '}
+                    <Link to="/paper/14-research-sources">research</Link>!){' '}
+                    {/* DONOTSUBMIT open in new tab */}
+                  </Trans>
+                </p>
+              ) : null}
             </div>
 
             {prevalenceIsFilled && scenarioIsFilled ? (

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -1,4 +1,5 @@
 import copy from 'copy-to-clipboard'
+import i18n from 'i18n'
 import { stringify } from 'query-string'
 import React, { useEffect, useMemo, useState } from 'react'
 import { Alert, Col, Row } from 'react-bootstrap'
@@ -17,7 +18,10 @@ import { FirstTimeUserIntroduction } from 'components/calculator/FirstTimeUserIn
 import { PersonRiskControls } from 'components/calculator/PersonRiskControls'
 import PointsDisplay from 'components/calculator/PointsDisplay'
 import { PrevalenceControls } from 'components/calculator/PrevalenceControls'
-import { SavedDataSelector } from 'components/calculator/SavedDataSelector'
+import {
+  SavedDataLink,
+  SavedDataSelector,
+} from 'components/calculator/SavedDataSelector'
 import { Card } from 'components/Card'
 import {
   CalculatorData,
@@ -137,6 +141,10 @@ export const Calculator = (): React.ReactElement => {
       calculatorData.casesIncreasingPercentage >= 0 &&
       calculatorData.positiveCasePercentage !== null &&
       calculatorData.positiveCasePercentage > 0)
+  const scenarioIsFilled =
+    (scenarioName !== undefined && scenarioName !== '') ||
+    (calculatorData.interaction !== undefined &&
+      calculatorData.interaction !== '')
   const repeatedEvent = ['repeated', 'partner'].includes(
     calculatorData.interaction,
   )
@@ -160,8 +168,24 @@ export const Calculator = (): React.ReactElement => {
           <p>
             <Trans i18nKey="calculator.intro.whats_this2">
               Lorem ipsum dolor sic amet...
-              <span>grocery store</span>,<span>see a specific person</span>,
-              <span>work precautions</span>,
+              <SavedDataLink
+                currentData={calculatorData}
+                setter={setCalculatorData}
+                scenarioName={i18n.t('scenario.60minShopping')}
+                scenarioNameSetter={setScenarioName}
+              >
+                grocery store
+              </SavedDataLink>
+              ,
+              <SavedDataLink
+                currentData={calculatorData}
+                setter={setCalculatorData}
+                scenarioName={i18n.t('scenario.outdoorMasked2')}
+                scenarioNameSetter={setScenarioName}
+              >
+                see a friend
+              </SavedDataLink>
+              ,<span>work precautions</span>
             </Trans>
           </p>
           <FirstTimeUserIntroduction />
@@ -228,47 +252,47 @@ export const Calculator = (): React.ReactElement => {
 
         <Col md="12" lg="8" id="activity-section">
           <Card id="person-risk">
-            {prevalenceIsFilled ? (
-              <React.Fragment>
-                <header id="activity-risk">
-                  <Trans>calculator.risk_step_label</Trans>
-                </header>
-                <Row>
-                  <Col className="calculator-buttons">
-                    <SavedDataSelector
-                      currentData={calculatorData}
-                      setter={setCalculatorData}
-                      scenarioName={scenarioName}
-                      scenarioNameSetter={setScenarioName}
-                    />
-                  </Col>
-                </Row>
-                {!scenarioName ? null : (
-                  <Alert variant="info">
-                    <Trans values={{ scenarioName: scenarioName }}>
-                      calculator.saved_scenario_loaded_message
-                    </Trans>
-                  </Alert>
-                )}
-                <div>
-                  <GenericSelectControl
-                    id="interaction"
-                    label={t('calculator.type_of_interaction')}
-                    // This setter defaults to a personCount of 1 if the interaction type is "partner"
-                    setter={(value) =>
-                      setCalculatorData({
-                        ...calculatorData,
-                        interaction: value,
-                        personCount:
-                          value === 'partner' ? 1 : calculatorData.personCount,
-                      })
-                    }
-                    value={calculatorData.interaction}
-                    source={Interaction}
-                    hideRisk={true}
-                  />
-                </div>
+            <header id="activity-risk">
+              <Trans>calculator.risk_step_label</Trans>
+            </header>
+            <Row>
+              <Col className="calculator-buttons">
+                <SavedDataSelector
+                  currentData={calculatorData}
+                  setter={setCalculatorData}
+                  scenarioName={scenarioName}
+                  scenarioNameSetter={setScenarioName}
+                />
+              </Col>
+            </Row>
+            {!scenarioName ? null : (
+              <Alert variant="info">
+                <Trans values={{ scenarioName: scenarioName }}>
+                  calculator.saved_scenario_loaded_message
+                </Trans>
+              </Alert>
+            )}
+            <div>
+              <GenericSelectControl
+                id="interaction"
+                label={t('calculator.type_of_interaction')}
+                // This setter defaults to a personCount of 1 if the interaction type is "partner"
+                setter={(value) =>
+                  setCalculatorData({
+                    ...calculatorData,
+                    interaction: value,
+                    personCount:
+                      value === 'partner' ? 1 : calculatorData.personCount,
+                  })
+                }
+                value={calculatorData.interaction}
+                source={Interaction}
+                hideRisk={true}
+              />
+            </div>
 
+            {prevalenceIsFilled && scenarioIsFilled ? (
+              <React.Fragment>
                 <Row>
                   <Col xs="12" id="person-risk" className="calculator-params">
                     <PersonRiskControls
@@ -309,7 +333,9 @@ export const Calculator = (): React.ReactElement => {
               </React.Fragment>
             ) : (
               <div className="empty">
-                <Trans>calculator.risk_group_empty_warning</Trans>
+                {scenarioIsFilled ? (
+                  <Trans>calculator.risk_group_empty_warning</Trans>
+                ) : null}
               </div>
             )}
           </Card>

--- a/src/pages/__tests__/Calculator.test.tsx
+++ b/src/pages/__tests__/Calculator.test.tsx
@@ -20,11 +20,23 @@ describe('calculator page', () => {
     )
 
     const interactionTypeLabelQuery = /Is this a specific activity or an ongoing relationship/i
-    expect(queryByText(interactionTypeLabelQuery)).not.toBeInTheDocument()
+    const peopleLabelQuery = /Nearby people/i
+
+    expect(getByText(interactionTypeLabelQuery)).toBeInTheDocument()
+    expect(queryByText(peopleLabelQuery)).not.toBeInTheDocument()
     const topLocationBox = getByPlaceholderText(/Select Country or US State/i)
     fireEvent.click(topLocationBox)
     const californiaOption = getByText(/California/i)
     fireEvent.click(californiaOption)
     expect(getByText(interactionTypeLabelQuery)).toBeInTheDocument()
+
+    const interactionTypeBox = getByText(/Select one/i)
+    fireEvent.click(interactionTypeBox)
+    const oneTimeOption = getByText(/One-time interaction/i)
+    fireEvent.click(oneTimeOption)
+
+    expect(getByText(interactionTypeLabelQuery)).toBeInTheDocument()
+    // DONOTSUBMIT why is this broken?
+    //expect(getByText(peopleLabelQuery)).toBeInTheDocument()
   })
 })

--- a/src/pages/styles/Calculator.scss
+++ b/src/pages/styles/Calculator.scss
@@ -169,6 +169,9 @@
     .rbt-input-main {
       font-size: $input-font-size-lg;
     }
+    .rbt-input-hint {
+      color: rgba(68,68,68,0.6) !important;
+    }
 
     .rbt-close {
       color: #444

--- a/src/pages/styles/Calculator.scss
+++ b/src/pages/styles/Calculator.scss
@@ -11,6 +11,11 @@
     font-size: $h4-font-size;
     position: relative;
 
+    .btn {
+      font-size: $h4-font-size !important;
+      vertical-align: baseline !important;
+    }
+
   }
 
   .request-feedback {


### PR DESCRIPTION
Before there are working links to presets in the intro text, there needs to be some sort of visual feedback even if a location hasn't been specified yet.

Unfortunately, I have no idea why this is breaking tests. Any ideas, @beshaya or @blanchardjeremy ?