### PR TITLE
Reword interaction type prompt

### DIFF
--- a/src/components/calculator/ExplanationCard/ExplanationCard.tsx
+++ b/src/components/calculator/ExplanationCard/ExplanationCard.tsx
@@ -141,7 +141,8 @@ export default function ExplanationCard(props: {
               )}
               <br />
               <Trans values={{ person_risk: personRiskEachFormatted }}>
-                {props.data.interaction !== 'oneTime' &&
+                {(props.data.interaction === 'partner' ||
+                  props.data.interaction === 'repeated') &&
                 RiskProfile[props.data.riskProfile].numHousemates >= 1
                   ? 'calculator.explanationcard.details_person_risk_explanation_housemate'
                   : 'calculator.explanationcard.details_person_risk_explanation'}

--- a/src/components/calculator/FirstTimeUserIntroduction.tsx
+++ b/src/components/calculator/FirstTimeUserIntroduction.tsx
@@ -17,12 +17,10 @@ export function FirstTimeUserIntroduction(): React.ReactElement {
         id="budget-intro"
         header={t('calculator.firsttime.budget_header')}
       >
-        <p>
-          <Trans i18nKey="calculator.firsttime.budget_explanation">
-            Lorem ipsum <a href="/paper/2-riskiness">riskyness link</a>
-            dolor sic <a href="/tracker">risk tracker link</a>
-          </Trans>
-        </p>
+        <Trans i18nKey="calculator.firsttime.budget_explanation">
+          Lorem ipsum <a href="/paper/2-riskiness">riskyness link</a>
+          dolor sic <a href="/tracker">risk tracker link</a>
+        </Trans>
       </Expandable>
     </>
   )

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -69,7 +69,6 @@ export const SavedDataSelector: React.FunctionComponent<{
             setSavedData(e[e.length - 1])
           }}
           options={prepopulatedOptions}
-          placeholder={t('calculator.select_scenario_placeholder')}
           selected={selected}
         />
       </InputGroup>

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import { Form, InputGroup } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import { useTranslation } from 'react-i18next'
+import { Trans } from 'react-i18next'
 import { BsSearch } from 'react-icons/bs'
 
+import { ControlLabel } from 'components/calculator/controls/ControlLabel'
 import { CalculatorData } from 'data/calculate'
 import { PartialData, prepopulated } from 'data/prepopulated'
 
@@ -39,6 +41,14 @@ export const SavedDataSelector: React.FunctionComponent<{
 
   return (
     <Form.Group>
+      <ControlLabel
+        id="predefined-typeahead"
+        label={
+          <Trans i18nKey="calculator.select_scenario">
+            Look for a premade scenario or <span>build your own</span>
+          </Trans>
+        }
+      />
       <InputGroup>
         <InputGroup.Prepend>
           <InputGroup.Text>
@@ -59,7 +69,7 @@ export const SavedDataSelector: React.FunctionComponent<{
             setSavedData(e[e.length - 1])
           }}
           options={prepopulatedOptions}
-          placeholder={t('calculator.select_scenario')}
+          placeholder={t('calculator.select_scenario_placeholder')}
           selected={selected}
         />
       </InputGroup>

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form, InputGroup } from 'react-bootstrap'
+import { Button, Form, InputGroup } from 'react-bootstrap'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import { useTranslation } from 'react-i18next'
 import { Trans } from 'react-i18next'
@@ -9,6 +9,39 @@ import { ControlLabel } from 'components/calculator/controls/ControlLabel'
 import { CalculatorData } from 'data/calculate'
 import { PartialData, prepopulated } from 'data/prepopulated'
 
+const SavedDataLink: React.FunctionComponent<{
+  currentData: CalculatorData
+  setter: (newData: CalculatorData) => void
+  scenarioName: string
+  scenarioNameSetter: (newScenario: string) => void
+}> = (props): React.ReactElement => {
+  const setSavedData = (key: string): void => {
+    let foundData: PartialData | CalculatorData | null = null
+    foundData = prepopulated[key]
+
+    if (foundData) {
+      props.setter({
+        ...props.currentData,
+        ...foundData,
+      })
+    }
+    props.scenarioNameSetter(key)
+  }
+
+  return (
+    <Button
+      className="p-0 m-0 border-0 scenario-shortcut"
+      onClick={() => {
+        setSavedData(props.scenarioName)
+        props.scenarioNameSetter(props.scenarioName)
+      }}
+      size="lg"
+      variant="link"
+    >
+      {props.children}
+    </Button>
+  )
+}
 export const SavedDataSelector: React.FunctionComponent<{
   currentData: CalculatorData
   setter: (newData: CalculatorData) => void
@@ -40,12 +73,20 @@ export const SavedDataSelector: React.FunctionComponent<{
   }
 
   return (
-    <Form.Group>
+    <Form.Group id="predefined-typeahead-group">
       <ControlLabel
         id="predefined-typeahead"
         label={
           <Trans i18nKey="calculator.select_scenario">
-            Look for a premade scenario or <span>build your own</span>
+            Look for a premade scenario or{' '}
+            <SavedDataLink
+              currentData={props.currentData}
+              setter={props.setter}
+              scenarioName={t('scenario.custom')}
+              scenarioNameSetter={props.scenarioNameSetter}
+            >
+              build your own
+            </SavedDataLink>
           </Trans>
         }
       />

--- a/src/components/calculator/SavedDataSelector.tsx
+++ b/src/components/calculator/SavedDataSelector.tsx
@@ -64,7 +64,7 @@ export const SavedDataSelector: React.FunctionComponent<{
           inputProps={{ autoComplete: 'chrome-off' }}
           onChange={(e: string[]) => {
             if (e.length === 0) {
-              setSavedData('')
+              setSavedData(t('scenario.custom'))
             }
             setSavedData(e[e.length - 1])
           }}

--- a/src/components/calculator/controls/ControlLabel.tsx
+++ b/src/components/calculator/controls/ControlLabel.tsx
@@ -4,7 +4,7 @@ import 'components/calculator/styles/ControlLabel.scss'
 
 export const ControlLabel: React.FunctionComponent<{
   id: string
-  label?: string
+  label?: string | JSX.Element
   header?: string
   popover?: JSX.Element
 }> = (props) => (

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -243,6 +243,24 @@ describe('calculate', () => {
     },
   )
 
+  describe('Interaction: workplace', () => {
+    const workplace = testData({
+      ...baseTestData,
+      ...repeatedDontCare,
+      riskProfile: 'average',
+      interaction: 'workplace',
+      personCount: 1,
+    })
+
+    it('should behave the same as a one time interaction', () => {
+      const oneTime: CalculatorData = {
+        ...workplace,
+        interaction: 'oneTime',
+      }
+      expect(calcValue(workplace)).toEqual(calcValue(oneTime))
+    })
+  })
+
   describe('Interaction: partner', () => {
     const partner = testData(
       prepopulated[

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -216,7 +216,8 @@ export const calculatePersonRiskEach = (
       // If risk profile isn't selected, call it incomplete
       return null
     }
-    const isHousemate = data.interaction !== 'oneTime'
+    const isHousemate =
+      data.interaction === 'partner' || data.interaction === 'repeated'
     return (
       averagePersonRisk *
       personRiskMultiplier({
@@ -236,7 +237,7 @@ export const calculateActivityRisk = (data: CalculatorData): number | null => {
       return null
     }
 
-    if (data.interaction !== 'oneTime') {
+    if (data.interaction === 'partner' || data.interaction === 'repeated') {
       return Interaction[data.interaction].multiplier
     }
 

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -42,6 +42,12 @@ export const Interaction: { [key: string]: FormValue } = {
     }),
     multiplier: oneTimeMult,
   },
+  workplace: {
+    label: i18n.t('data.workplace', {
+      percentage: fixedPointPrecisionPercent(oneTimeMult),
+    }),
+    multiplier: oneTimeMult,
+  },
   partner: {
     label: i18n.t('data.partner', {
       percentage: fixedPointPrecisionPercent(partnerMult),

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -42,17 +42,17 @@ export const Interaction: { [key: string]: FormValue } = {
     }),
     multiplier: oneTimeMult,
   },
-  repeated: {
-    label: i18n.t('data.repeated', {
-      percentage: fixedPointPrecisionPercent(housemateMult),
-    }),
-    multiplier: housemateMult,
-  },
   partner: {
     label: i18n.t('data.partner', {
       percentage: fixedPointPrecisionPercent(partnerMult),
     }),
     multiplier: partnerMult,
+  },
+  repeated: {
+    label: i18n.t('data.repeated', {
+      percentage: fixedPointPrecisionPercent(housemateMult),
+    }),
+    multiplier: housemateMult,
   },
 }
 

--- a/src/data/prepopulated.ts
+++ b/src/data/prepopulated.ts
@@ -18,6 +18,20 @@ export type PartialData = Omit<
 export const prepopulated: {
   [key: string]: PartialData
 } = {
+  [i18n.t('scenario.custom')]: {
+    // This special profile is applied to reset the rest of the calculator.
+    riskProfile: '',
+    interaction: '',
+    personCount: 0,
+    symptomsChecked: 'no',
+
+    setting: '',
+    distance: '',
+    duration: 0,
+    theirMask: '',
+    yourMask: '',
+    voice: '',
+  },
   [i18n.t('scenario.outdoorMasked2')]: {
     riskProfile: 'average',
     interaction: 'oneTime',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,7 @@
       "enter_data_manually": "Override location-based data"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), <7>Our World in Data</7> (international positive test rates), and <10>Coronavirus COVID-19 România</10> (Romania reported cases).",
-    "select_scenario": "Look for a premade scenario or <1>build your own</1>:",
+    "select_scenario": "Start with a premade scenario or <2>build your own</2>:",
     "no_prebuilt_scenario_found": "We don't have this scenario yet, but you can build your own below.",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
@@ -156,7 +156,7 @@
     "partner_interaction_risk_message": "If this person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
     "whats_next_interaction_risk_message": "How likely is it someone is infected? It depends on your location and the choices of people around you. This calculator will also walk you through <1>choices you can make</1> to change the baseline risk (backed by <4>research</4>!)",
     "risk_group_empty_warning": "Enter your location first.",
-    "saved_scenario_loaded_message": "If needed, adjust these prefilled answers for the <strong>{{ scenarioName }}</strong> scenario.",
+    "saved_scenario_loaded_message": "If needed, adjust the following prefilled answers to match your <strong>{{ scenarioName }}</strong> scenario.",
     "alerts": {
       "masks_update": "<0>January 28th, 2021:</0> We added new mask types, and updated multipliers for existing ones. Learn more in <3>our new blog post about masks</3>.",
       "b117": "<0>January 5th, 2021:</0> The calculator now accounts for the new more infectious COVID-19 variant B117. Read more <3>here</3>.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,7 +127,6 @@
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), <7>Our World in Data</7> (international positive test rates), and <10>Coronavirus COVID-19 România</10> (Romania reported cases).",
     "select_scenario": "Look for a premade scenario or <1>build your own</1>:",
-    "select_scenario_placeholder": "Custom scenario",
     "no_prebuilt_scenario_found": "We don't have this scenario yet, but you can build your own below.",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
@@ -173,7 +172,8 @@
     "select_default_action": "Select one..."
   },
   "data": {
-    "oneTime": "How risky is this gathering/activity/errand/workplace?",
+    "oneTime": "How risky is this gathering/activity/errand?",
+    "workplace": "How risky is going in to work?",
     "partner": "How risky is it to live/stay with a partner/spouse?",
     "repeated": "How risky is it to live/stay with others (like roommates or family)?",
     "indoor": "Indoor",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -126,7 +126,8 @@
       "enter_data_manually": "Override location-based data"
     },
     "prevalence_info_source_information": "Prevalence data consolidated from <1>Johns Hopkins CSSE</1> (reported cases), <4>Covid Act Now</4> (US positive test rates), <7>Our World in Data</7> (international positive test rates), and <10>Coronavirus COVID-19 România</10> (Romania reported cases).",
-    "select_scenario": "Search for an activity or build your own below...",
+    "select_scenario": "Look for a premade scenario or <1>build your own</1>:",
+    "select_scenario_placeholder": "Custom scenario",
     "no_prebuilt_scenario_found": "We don't have this scenario yet, but you can build your own below.",
     "baseline_risk": "baseline risk",
     "risk_modifier_frac_2nd": "{{frac}} the risk",
@@ -149,10 +150,15 @@
       "see_video": "If you'd like to watch a video walkthrough of how to use the calculator, click <1>here</1>.",
       "call_to_action": "Calculate the approximate COVID risk of an activity or relationship"
     },
-    "risk_step_label": "Step 2: Describe the activity or relationship",
-    "type_of_interaction": "Is this a specific activity or an ongoing relationship?",
-    "risk_group_empty_warning": "First, enter your location",
+    "risk_step_label": "Step 2: Describe the scenario",
+    "type_of_interaction": "What do you want to learn?",
+    "one_time_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per hour</1>.",
+    "repeated_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
+    "partner_interaction_risk_message": "If this person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
+    "whats_next_interaction_risk_message": "How likely is it someone is infected? It depends on your location and the choices of people around you. This calculator will also walk you through <1>choices you can make</1> to change the baseline risk (backed by <4>research</4>!)",
+    "risk_group_empty_warning": "Enter your location first.",
     "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
+    "custom_scenario_message": "You are building your own scenario. <strong>Fill out the calculator</strong> to learn how risky it is.",
     "alerts": {
       "masks_update": "<0>January 28th, 2021:</0> We added new mask types, and updated multipliers for existing ones. Learn more in <3>our new blog post about masks</3>.",
       "b117": "<0>January 5th, 2021:</0> The calculator now accounts for the new more infectious COVID-19 variant B117. Read more <3>here</3>.",
@@ -167,9 +173,9 @@
     "select_default_action": "Select one..."
   },
   "data": {
-    "oneTime": "One-time interaction or repeated activity [{{ percentage }} chance of transmission per hour]",
-    "repeated": "Household member, or visitor staying at your home [{{ percentage }} chance of transmission per week]",
-    "partner": "Partner / spouse [{{ percentage }} chance of transmission per week]",
+    "oneTime": "How risky is this gathering/activity/errand/workplace?",
+    "partner": "How risky is it to live/stay with a partner/spouse?",
+    "repeated": "How risky is it to live/stay with others (like roommates or family)?",
     "indoor": "Indoor",
     "filtered": "Indoors with a HEPA filter (flow rate 5x room size)",
     "transit": "A train with air filtration",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -220,6 +220,7 @@
     }
   },
   "scenario": {
+    "custom": "Build your own scenario",
     "outdoorMasked2": "Outdoor masked hangout with 2 other people",
     "indoorUnmasked2": "Indoor unmasked hangout with 2 other people",
     "1person_15minCarRide": "Car ride with 1 other person for 15 mins",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -150,14 +150,13 @@
       "call_to_action": "Calculate the approximate COVID risk of an activity or relationship"
     },
     "risk_step_label": "Step 2: Describe the scenario",
-    "type_of_interaction": "What do you want to learn?",
+    "type_of_interaction": "What do you want to know?",
     "one_time_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per hour</1>.",
     "repeated_interaction_risk_message": "If one person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
     "partner_interaction_risk_message": "If this person is infected, there is a baseline <1>{{ percentage }} chance of transmission per week</1>.",
     "whats_next_interaction_risk_message": "How likely is it someone is infected? It depends on your location and the choices of people around you. This calculator will also walk you through <1>choices you can make</1> to change the baseline risk (backed by <4>research</4>!)",
     "risk_group_empty_warning": "Enter your location first.",
-    "saved_scenario_loaded_message": "You selected this scenario: <strong>{{ scenarioName }}</strong>. Do the points below look like the activity you have in mind? If not, adjust it until it looks right.",
-    "custom_scenario_message": "You are building your own scenario. <strong>Fill out the calculator</strong> to learn how risky it is.",
+    "saved_scenario_loaded_message": "If needed, adjust these prefilled answers for the <strong>{{ scenarioName }}</strong> scenario.",
     "alerts": {
       "masks_update": "<0>January 28th, 2021:</0> We added new mask types, and updated multipliers for existing ones. Learn more in <3>our new blog post about masks</3>.",
       "b117": "<0>January 5th, 2021:</0> The calculator now accounts for the new more infectious COVID-19 variant B117. Read more <3>here</3>.",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -18,6 +18,7 @@ import { PersonRiskControls } from 'components/calculator/PersonRiskControls'
 import PointsDisplay from 'components/calculator/PointsDisplay'
 import { PrevalenceControls } from 'components/calculator/PrevalenceControls'
 import { SavedDataSelector } from 'components/calculator/SavedDataSelector'
+import { fixedPointPrecisionPercent } from 'components/calculator/util/FormatPrecision'
 import { Card } from 'components/Card'
 import {
   CalculatorData,
@@ -153,6 +154,25 @@ export const Calculator = (): React.ReactElement => {
 
   const { t } = useTranslation()
 
+  const SavedScenarioMessage: React.FunctionComponent<{
+    scenarioName: string
+  }> = (props): React.ReactElement => {
+    if (props.scenarioName === t('scenario.custom')) {
+      return (
+        <Alert variant="info">
+          <Trans>calculator.custom_scenario_message</Trans>
+        </Alert>
+      )
+    } else {
+      return (
+        <Alert variant="info">
+          <Trans values={{ scenarioName: scenarioName }}>
+            calculator.saved_scenario_loaded_message
+          </Trans>
+        </Alert>
+      )
+    }
+  }
   return (
     <div id="calculator">
       <Row>
@@ -244,11 +264,7 @@ export const Calculator = (): React.ReactElement => {
                   </Col>
                 </Row>
                 {!scenarioName ? null : (
-                  <Alert variant="info">
-                    <Trans values={{ scenarioName: scenarioName }}>
-                      calculator.saved_scenario_loaded_message
-                    </Trans>
-                  </Alert>
+                  <SavedScenarioMessage scenarioName={scenarioName} />
                 )}
                 <div>
                   <GenericSelectControl
@@ -267,8 +283,61 @@ export const Calculator = (): React.ReactElement => {
                     source={Interaction}
                     hideRisk={true}
                   />
+                  {calculatorData.interaction === 'oneTime' ? (
+                    <Alert variant="info">
+                      <Trans
+                        i18nKey="calculator.one_time_interaction_risk_message"
+                        values={{
+                          percentage: fixedPointPrecisionPercent(
+                            Interaction['oneTime'].multiplier,
+                          ),
+                        }}
+                      >
+                        Lorem ipsum <strong>dolor</strong> sit
+                      </Trans>
+                    </Alert>
+                  ) : null}
+                  {calculatorData.interaction === 'repeated' ? (
+                    <Alert variant="info">
+                      <Trans
+                        i18nKey="calculator.repeated_interaction_risk_message"
+                        values={{
+                          percentage: fixedPointPrecisionPercent(
+                            Interaction[calculatorData.interaction].multiplier,
+                          ),
+                        }}
+                      >
+                        Lorem ipsum <strong>dolor</strong>
+                      </Trans>
+                    </Alert>
+                  ) : null}
+                  {calculatorData.interaction === 'partner' ? (
+                    <Alert variant="info">
+                      <Trans
+                        i18nKey="calculator.partner_interaction_risk_message"
+                        values={{
+                          percentage: fixedPointPrecisionPercent(
+                            Interaction[calculatorData.interaction].multiplier,
+                          ),
+                        }}
+                      >
+                        Lorem ipsum <strong>dolor</strong>
+                      </Trans>
+                    </Alert>
+                  ) : null}
+                  {calculatorData.interaction !== undefined &&
+                  calculatorData.interaction !== '' ? (
+                    <p>
+                      <Trans i18nKey="calculator.whats_next_interaction_risk_message">
+                        Lorem ipsum dolor <strong>sit amet</strong>
+                        (backed by{' '}
+                        <Link to="/paper/14-research-sources">
+                          research
+                        </Link>!) {/* DONOTSUBMIT open in new tab */}
+                      </Trans>
+                    </p>
+                  ) : null}
                 </div>
-
                 <Row>
                   <Col xs="12" id="person-risk" className="calculator-params">
                     <PersonRiskControls

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -283,7 +283,8 @@ export const Calculator = (): React.ReactElement => {
                     source={Interaction}
                     hideRisk={true}
                   />
-                  {calculatorData.interaction === 'oneTime' ? (
+                  {calculatorData.interaction === 'oneTime' ||
+                  calculatorData.interaction === 'workplace' ? (
                     <Alert variant="info">
                       <Trans
                         i18nKey="calculator.one_time_interaction_risk_message"

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -156,23 +156,32 @@ export const Calculator = (): React.ReactElement => {
 
   const SavedScenarioMessage: React.FunctionComponent<{
     scenarioName: string
-  }> = (props): React.ReactElement => {
-    if (props.scenarioName === t('scenario.custom')) {
-      return (
-        <Alert variant="info">
-          <Trans>calculator.custom_scenario_message</Trans>
-        </Alert>
-      )
-    } else {
-      return (
-        <Alert variant="info">
-          <Trans values={{ scenarioName: scenarioName }}>
-            calculator.saved_scenario_loaded_message
-          </Trans>
-        </Alert>
-      )
-    }
-  }
+  }> = (props): React.ReactElement => (
+    <Alert variant="info">
+      <Trans values={{ scenarioName: props.scenarioName }}>
+        calculator.saved_scenario_loaded_message
+      </Trans>
+    </Alert>
+  )
+
+  const BaseTransmissionRateMessage: React.FunctionComponent<{
+    interaction: string
+    messageKey: string
+  }> = (props): React.ReactElement => (
+    <Alert variant="info">
+      <Trans
+        i18nKey={props.messageKey}
+        values={{
+          percentage: fixedPointPrecisionPercent(
+            Interaction[props.interaction].multiplier,
+          ),
+        }}
+      >
+        Lorem ipsum <strong>dolor</strong> sit
+      </Trans>
+    </Alert>
+  )
+
   return (
     <div id="calculator">
       <Row>
@@ -263,7 +272,8 @@ export const Calculator = (): React.ReactElement => {
                     />
                   </Col>
                 </Row>
-                {!scenarioName ? null : (
+                {!scenarioName ||
+                scenarioName === t('scenario.custom') ? null : (
                   <SavedScenarioMessage scenarioName={scenarioName} />
                 )}
                 <div>
@@ -285,46 +295,22 @@ export const Calculator = (): React.ReactElement => {
                   />
                   {calculatorData.interaction === 'oneTime' ||
                   calculatorData.interaction === 'workplace' ? (
-                    <Alert variant="info">
-                      <Trans
-                        i18nKey="calculator.one_time_interaction_risk_message"
-                        values={{
-                          percentage: fixedPointPrecisionPercent(
-                            Interaction['oneTime'].multiplier,
-                          ),
-                        }}
-                      >
-                        Lorem ipsum <strong>dolor</strong> sit
-                      </Trans>
-                    </Alert>
+                    <BaseTransmissionRateMessage
+                      interaction={calculatorData.interaction}
+                      messageKey="calculator.one_time_interaction_risk_message"
+                    />
                   ) : null}
                   {calculatorData.interaction === 'repeated' ? (
-                    <Alert variant="info">
-                      <Trans
-                        i18nKey="calculator.repeated_interaction_risk_message"
-                        values={{
-                          percentage: fixedPointPrecisionPercent(
-                            Interaction[calculatorData.interaction].multiplier,
-                          ),
-                        }}
-                      >
-                        Lorem ipsum <strong>dolor</strong>
-                      </Trans>
-                    </Alert>
+                    <BaseTransmissionRateMessage
+                      interaction={calculatorData.interaction}
+                      messageKey="calculator.repeated_interaction_risk_message"
+                    />
                   ) : null}
                   {calculatorData.interaction === 'partner' ? (
-                    <Alert variant="info">
-                      <Trans
-                        i18nKey="calculator.partner_interaction_risk_message"
-                        values={{
-                          percentage: fixedPointPrecisionPercent(
-                            Interaction[calculatorData.interaction].multiplier,
-                          ),
-                        }}
-                      >
-                        Lorem ipsum <strong>dolor</strong>
-                      </Trans>
-                    </Alert>
+                    <BaseTransmissionRateMessage
+                      interaction={calculatorData.interaction}
+                      messageKey="calculator.partner_interaction_risk_message"
+                    />
                   ) : null}
                   {calculatorData.interaction !== undefined &&
                   calculatorData.interaction !== '' ? (
@@ -332,9 +318,10 @@ export const Calculator = (): React.ReactElement => {
                       <Trans i18nKey="calculator.whats_next_interaction_risk_message">
                         Lorem ipsum dolor <strong>sit amet</strong>
                         (backed by{' '}
-                        <Link to="/paper/14-research-sources">
+                        <Link to="/paper/14-research-sources" target="_blank">
                           research
-                        </Link>!) {/* DONOTSUBMIT open in new tab */}
+                        </Link>
+                        !)
                       </Trans>
                     </p>
                   ) : null}

--- a/src/pages/__tests__/Calculator.test.tsx
+++ b/src/pages/__tests__/Calculator.test.tsx
@@ -19,7 +19,7 @@ describe('calculator page', () => {
       },
     )
 
-    const interactionTypeLabelQuery = /Is this a specific activity or an ongoing relationship/i
+    const interactionTypeLabelQuery = /What do you want to learn/i
     expect(queryByText(interactionTypeLabelQuery)).not.toBeInTheDocument()
     const topLocationBox = getByPlaceholderText(/Select Country or US State/i)
     fireEvent.click(topLocationBox)

--- a/src/pages/__tests__/Calculator.test.tsx
+++ b/src/pages/__tests__/Calculator.test.tsx
@@ -19,7 +19,7 @@ describe('calculator page', () => {
       },
     )
 
-    const interactionTypeLabelQuery = /What do you want to learn/i
+    const interactionTypeLabelQuery = /What do you want to know/i
     expect(queryByText(interactionTypeLabelQuery)).not.toBeInTheDocument()
     const topLocationBox = getByPlaceholderText(/Select Country or US State/i)
     fireEvent.click(topLocationBox)

--- a/src/pages/styles/Calculator.scss
+++ b/src/pages/styles/Calculator.scss
@@ -188,4 +188,8 @@
       text-decoration: initial;
     }
   }
+
+  label[for=predefined-typeahead] {
+    text-align: left;
+  }
 }


### PR DESCRIPTION
* adjust interaction type text
* move chance of transmission out of dropdown into calculator body
* signal what's coming in the rest of the calculator
* update calculator page test and fix warning
* add custom scenario option to the typeahead

I pulled this out of draft #741 because it was getting kind of large and messy.