### PR TITLE
i18n: removing Norwegian translation from the selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,6 @@ export const App = (): React.ReactElement => {
                     <Dropdown.Item href="?lng=es">Español</Dropdown.Item>
                     <Dropdown.Item href="?lng=fr">Français</Dropdown.Item>
                     <Dropdown.Item href="?lng=hu">Magyar</Dropdown.Item>
-                    <Dropdown.Item href="?lng=nb">Norsk</Dropdown.Item>
                   </DropdownButton>
                 </Nav>
               </Navbar.Collapse>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -8,7 +8,6 @@ import en from './locales/en.json'
 import es from './locales/es.json'
 import fr from './locales/fr.json'
 import hu from './locales/hu.json'
-import nb from './locales/nb_NO.json'
 
 i18n
   .use(LanguageDetector)
@@ -20,7 +19,6 @@ i18n
       de: { translation: de },
       hu: { translation: hu },
       cs: { translation: cs },
-      nb: { translation: nb },
       es: { translation: es },
     },
     fallbackLng: 'en',


### PR DESCRIPTION
The coverage of the translation dropped to 60%, making it very
confusing. Removing it temporarily until translators on Weblate have a
chance to catch up.

This reverts commit 362ccdd799ad7ddd86b288019ed0b19fc3f2a888.