### PR TITLE
Easier Risk Tracker release process

### DIFF
--- a/src/components/RiskTrackerUtil.tsx
+++ b/src/components/RiskTrackerUtil.tsx
@@ -4,6 +4,9 @@ import React from 'react'
 export const spreadsheetUrl =
   'https://docs.google.com/spreadsheets/d/1W3_RxaLrqILJae6Uw-I1D9opP5tKVA694OhdGusNwMs'
 // Do not include '/edit' at the end of the URL, because we append different paths like /copy or /template/preview depending on the use case
+export const riskTrackerVersion = '2.2.3'
+export const riskTrackerReleaseDate = '2021-03-16'
+// Reminder: Make sure to bump the version number that gets imported into their copies of the spreadsheet. Located at: /public/tracker/latest_version_number.csv
 
 export const mailchimpSubscribeUrl = 'http://eepurl.com/hb6y4T'
 

--- a/src/pages/RiskTracker.tsx
+++ b/src/pages/RiskTracker.tsx
@@ -8,7 +8,12 @@ import activityModeling from './img/activity-modeling.png'
 import podOverviewIntro from './img/budget-overview.png'
 import { DropdownNav } from 'components/DropdownNav'
 import { MarkdownContents } from 'components/markdown/PaperPage'
-import { mailchimpLink, spreadsheetUrl } from 'components/RiskTrackerUtil'
+import {
+  mailchimpLink,
+  riskTrackerReleaseDate,
+  riskTrackerVersion,
+  spreadsheetUrl,
+} from 'components/RiskTrackerUtil'
 import { TableOfContents } from 'components/TableOfContents'
 import { pages } from 'posts/tracker/index'
 
@@ -160,9 +165,9 @@ export const RiskTrackerTOC = (): React.ReactElement => {
           of the spreadsheet to have the latest upgrades and bug fixes.
         </p>
         <p>
-          <strong>Current version:</strong> 2.2
+          <strong>Current version:</strong> {riskTrackerVersion}
           <br />
-          <strong>Released on:</strong> 2021-03-16
+          <strong>Released on:</strong> {riskTrackerReleaseDate}
           <br />
           🕑{' '}
           <a href="https://docs.google.com/document/d/1iwTFoCS8lOIWWm-ZzcMZ_mPHgA8tHVVA3yhKY23gDu8">


### PR DESCRIPTION
Move the version number next to the spreadsheet URL so we can change everything at once.