### PR TITLE
RFC: discuss vaccine protection from severe COVID

### DIFF
--- a/src/posts/paper/13-q-and-a.ts
+++ b/src/posts/paper/13-q-and-a.ts
@@ -212,9 +212,7 @@ While the vaccines are nowhere near making you invulnerable to COVID, remember t
 
 ### 2. If a vaccinated individual contracts COVID, how much less (or more) likely is this to result in negative consequences? (Increased budget)
 
-Data from Israel's study suggests that Pfizer's vaccine reduced cases of severe COVID by 92%, about the same as the reduction in mild/asymptomatic COVID. Therefore we do not think that mRNA vaccines reduce the chance of hospitalization or death beyond the reduction in contracting COVID in the first place. It is possible that the traditional vaccines (AstraZenica, Johnson&Johnson) are somewhat more protective againt severe COVID than mild COVID, but we have not seen compelling data for this.
-
-Additionally, we have seen [data](https://pubs.rsna.org/doi/full/10.1148/ryct.2020200110) suggesting that asymptomatic COVID-19 could result in lung damage in half of cases.
+We have seen [data](https://pubs.rsna.org/doi/full/10.1148/ryct.2020200110) suggesting that asymptomatic COVID-19 could result in lung damage in half of cases.
 
 As a result, getting a vaccination yourself confers a reduction in incoming microCOVIDs (as outlined [above](#1-how-much-less-likely-is-it-for-vaccinated-individuals-to-catch-covid-reduction-in-microcovids)),
 but we do not recommend increasing your microCOVID budget on top of that given current data.


### PR DESCRIPTION
Is the following statement in Q&A still in agreement with the available
scientific evidence and consensus?

> Data from Israel's study suggests that Pfizer's vaccine reduced
> cases of severe COVID by 92%, about the same as the reduction in
> mild/asymptomatic COVID. Therefore we do not think that mRNA vaccines
> reduce the chance of hospitalization or death beyond the reduction
> in contracting COVID in the first place. It is possible that the
> traditional vaccines (AstraZenica, Johnson&Johnson) are somewhat more
> protective againt severe COVID than mild COVID, but we have not seen
> compelling data for this.

If not, should it be tweaked or removed?

For example, [Wikipedia](https://en.wikipedia.org/w/index.php?title=COVID-19_vaccine&oldid=1019606401)
lists 100% protection against death or hospitalization for every vaccine,
with the possible exception of CoronaVac (ie. Sinovac).
![Wiki_covid_efficacy](https://user-images.githubusercontent.com/853754/115959826-24144280-a4dc-11eb-8bbf-1938381cca4f.png)

Links to the evidence in question:
[Moderna](https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=e0651c7a-2fe2-459d-a766-0d59e919f058)
> Severe COVID-19 symptoms observed in the Moderna vaccine trials, were defined as symptoms having
> met the criteria for mild/moderate symptoms plus any of the following observations: Clinical signs
> indicative of severe systemic illness, respiratory rate ≥30 per minute, heart rate ≥125 beats per minute,
> SpO2 ≤93% on room air at sea level or PaO2/FIO2 <300 mm Hg; or respiratory failure or ARDS,
> (defined as needing high-flow oxygen, non-invasive or mechanical ventilation, or ECMO), evidence
> of shock (systolic blood pressure <90 mmHg, diastolic BP <60 mmHg or requiring vasopressors); or
> significant acute renal, hepatic, or neurologic dysfunction; or admission to an intensive care unit
> or death. No severe cases were detected for vaccinated individuals in the trials, compared with 30
> severe cases reported in the placebo group (incidence rate 9.1 per 1000 person-years).

AstraZeneca [one](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7894131) [two](https://www.astrazeneca.com/content/astraz/media-centre/press-releases/2021/azd1222-us-phase-iii-primary-analysis-confirms-safety-and-efficacy.html)
> 100% efficacy against severe or critical disease and hospitalisation
[COVID-19 Vaccine AstraZeneca confirms 100% protection against severe disease, hospitalisation and death in the primary analysis of Phase III trials.](https://www.astrazeneca.com/media-centre/press-releases/2021/covid-19-vaccine-astrazeneca-confirms-protection-against-severe-disease-hospitalisation-and-death-in-the-primary-analysis-of-phase-iii-trials.html)

[J&J](https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=14a822ff-f353-49f9-a7f2-21424b201e3b)
> No hospitalizations or deaths were detected 28 days post-vaccination for 19,630 vaccinated
> individuals in the trials, compared with 16 hospitalizations reported in the placebo group
> of 19,691 individuals (incidence rate 5.2 per 1000 person-years)[160] and 7 COVID-19 related
> deaths for the same placebo group.

Fixes #837