### PR TITLE
Update single shot efficacy of Moderna/Pfizer

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -364,11 +364,11 @@ export interface VaccineValue {
 export const Vaccines: { [key: string]: VaccineValue } = {
   pfizer: {
     label: i18n.t('data.vaccine.pfizer'),
-    multiplierPerDose: [1, 0.56, 0.1],
+    multiplierPerDose: [1, 0.2, 0.1],
   },
   moderna: {
     label: i18n.t('data.vaccine.moderna'),
-    multiplierPerDose: [1, 0.56, 0.1],
+    multiplierPerDose: [1, 0.2, 0.1],
   },
   astraZeneca: {
     label: i18n.t('data.vaccine.astra_zeneca'),


### PR DESCRIPTION
The CDC reports an efficacy of 80%, 14 days after a first shot of Moderna or Pfizer. This figure includes both symptomatic and asymptomatic cases:
https://www.cdc.gov/mmwr/volumes/70/wr/mm7013e3.htm?s_cid=mm7013e3_w

When more data was collected, the figure was updated to 82%: https://www.cdc.gov/media/releases/2021/p0514-covid-19-vaccine-effectiveness.html

To me, based on these results, it would seem more reasonable to assume that asymptomatic cases are prevented at the same rate that symptomatic cases are prevented. If so, the (safe/pessimistic) correction for asymptomatic cases, as used in the current figure ((0.4 + .42 * .23) / (0.8 + .42 * .2) = 0.56), could be omitted. The figures for the efficacy of other vaccines could be updated based on that.

Discussion:
- this data was gathered among health care workers only (although they did partial corrections for this)
- the 95% CI reported by CDC is 80% [59%–90%]
- the CDC warns that sensitivity of the used PCR tests could affect the outcome of the study

Is 56% still the best estimate? Is 20% more reasonable? Should we go for a middle ground? Let's discuss.

p.s. I love the microcovid project, thanks for working on this!!!