### PR TITLE
Remove prettier/lint for locations.ts

### DIFF
--- a/src/data/location.ts
+++ b/src/data/location.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 // TODO(bshaya): Migrate from `type | null` to `?: type`
 export interface Location {
   label: string


### PR DESCRIPTION
We're currently getting this error for locations.ts

![image](https://user-images.githubusercontent.com/32290/129661457-497c58eb-07d4-40b7-9a30-b62868054a2f.png)


Which is happening because the list/array is supposed to be on multiple lines:

![image](https://user-images.githubusercontent.com/32290/129661552-59f40b9a-01d8-4640-8348-34c39ec73233.png)


I don't know how to resolve this, so I figured I'd just turn off lint. That might be poor form. So I'm open to other ideas.