### PR TITLE
Add option to jump to error when form data missing

### DIFF
--- a/src/components/calculator/DurationInput.tsx
+++ b/src/components/calculator/DurationInput.tsx
@@ -18,6 +18,7 @@ export function DurationInput(props: {
           <Trans>calculator.duration_question</Trans>
         </label>
         <input
+          id="durationInput"
           className="form-control form-control-lg col-md-3"
           type="number"
           inputMode="numeric"

--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -12,7 +12,7 @@ import {
   displayPoints,
   showPoints,
 } from 'components/calculator/util/displayUtil'
-import { ONE_MILLION } from 'data/calculate'
+import { CalculatorData, ONE_MILLION } from 'data/calculate'
 import 'components/calculator/styles/PointsDisplay.scss'
 
 export interface RiskLevel {
@@ -113,14 +113,47 @@ function Thermometer(props: {
   )
 }
 
+function getErrorElementSelector(data: CalculatorData) {
+  if (data.interaction === '') {
+    return null
+  }
+  if (data.duration === 0) {
+    return '#durationInput'
+  } else if (data.riskProfile === '') {
+    return '#riskProfile'
+  }
+  return null
+}
+
+function MissingDataWarning(props: { data: CalculatorData }): JSX.Element {
+  const selector = getErrorElementSelector(props.data)
+  return (
+    <>
+      <Trans>calculator.pointsdisplay.empty_warning</Trans>{' '}
+      {selector && (
+        <a
+          className="jump-to-error"
+          onClick={() => {
+            const errorElement = document.querySelector(selector) as HTMLElement
+            errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            errorElement.focus({ preventScroll: true })
+          }}
+        >
+          (<Trans>calculator.pointsdisplay.jump_to_error</Trans>)
+        </a>
+      )}
+    </>
+  )
+}
+
 export default function PointsDisplay(props: {
+  data: CalculatorData
   points: number
   repeatedEvent: boolean
-  riskBudget: number
   upperBound: number
   lowerBound: number
 }): React.ReactElement {
-  const activeRiskLevel = howRisky(props.points, props.riskBudget)
+  const activeRiskLevel = howRisky(props.points, props.data.riskBudget)
   const doShowPoints = showPoints(props.points)
   const { t } = useTranslation()
   const riskLabel = (name: string): string => {
@@ -163,7 +196,7 @@ export default function PointsDisplay(props: {
             <>
               {budgetConsumption(
                 props.points,
-                props.riskBudget,
+                props.data.riskBudget,
                 t('calculator.explanationcard.multiple_suffix'),
                 t('calculator.explanationcard.percentage_suffix'),
               )}
@@ -194,7 +227,7 @@ export default function PointsDisplay(props: {
               </span>
             </>
           ) : (
-            <Trans>calculator.pointsdisplay.empty_warning</Trans>
+            <MissingDataWarning data={props.data} />
           )}
         </div>
       </Col>

--- a/src/components/calculator/PointsDisplay.tsx
+++ b/src/components/calculator/PointsDisplay.tsx
@@ -131,7 +131,7 @@ function MissingDataWarning(props: { data: CalculatorData }): JSX.Element {
     <>
       <Trans>calculator.pointsdisplay.empty_warning</Trans>{' '}
       {selector && (
-        <a
+        <button
           className="jump-to-error"
           onClick={() => {
             const errorElement = document.querySelector(selector) as HTMLElement
@@ -140,7 +140,7 @@ function MissingDataWarning(props: { data: CalculatorData }): JSX.Element {
           }}
         >
           (<Trans>calculator.pointsdisplay.jump_to_error</Trans>)
-        </a>
+        </button>
       )}
     </>
   )

--- a/src/components/calculator/__tests__/PointsDisplay.test.tsx
+++ b/src/components/calculator/__tests__/PointsDisplay.test.tsx
@@ -7,9 +7,36 @@ import PointsDisplay from 'components/calculator/PointsDisplay'
 
 const standardPointsDisplay = (
   <PointsDisplay
+    data={{
+      riskBudget: 10000,
+      useManualEntry: 0,
+      topLocation: '',
+      subLocation: '',
+      subSubLocation: null,
+      population: '',
+      casesPastWeek: 0,
+      casesIncreasingPercentage: 0,
+      positiveCasePercentage: null,
+      prevalanceDataDate: new Date(),
+      percentFullyVaccinated: null,
+      unvaccinatedPrevalenceRatio: null,
+      averageFullyVaccinatedMultiplier: null,
+      riskProfile: 'average',
+      interaction: '',
+      personCount: 0,
+      symptomsChecked: '',
+      setting: '',
+      distance: '',
+      duration: 0,
+      theirMask: '',
+      yourMask: '',
+      voice: '',
+      yourVaccineType: '',
+      yourVaccineDoses: 0,
+      theirVaccine: '',
+    }}
     points={10}
     repeatedEvent={false}
-    riskBudget={10000}
     upperBound={300}
     lowerBound={30}
   />

--- a/src/components/calculator/styles/PointsDisplay.scss
+++ b/src/components/calculator/styles/PointsDisplay.scss
@@ -41,7 +41,11 @@ $sticky-z-index: 100;
 
 .jump-to-error { 
   color: $link-color;
-  text-decoration: underline
+  text-decoration: underline;
+  background: none;
+  border: none;
+  padding: 0;
+  font-weight: bold;
 }
 
 #calculator .top-half-card {

--- a/src/components/calculator/styles/PointsDisplay.scss
+++ b/src/components/calculator/styles/PointsDisplay.scss
@@ -39,6 +39,11 @@ $sticky-z-index: 100;
 .text-risk-low { color: $thermometer-light-green; }
 .text-risk-very-low { color: $thermometer-green; }
 
+.jump-to-error { 
+  color: $link-color;
+  text-decoration: underline
+}
+
 #calculator .top-half-card {
   background: white;
   border-top-left-radius: 8px;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -138,6 +138,7 @@
     "person_risk_profile_question": "What is their risk profile?",
     "pointsdisplay": {
       "empty_warning": "Fill in calculator to see risk level",
+      "jump_to_error": "Jump to error",
       "microCOVIDs": "microCOVIDs",
       "range": "probably between: {{ from }} to {{ to }}"
     },

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -421,9 +421,9 @@ export const Calculator = (): React.ReactElement => {
       <Row className="sticky" id="points-row">
         <Col md="12" lg={{ span: 8, offset: 4 }}>
           <PointsDisplay
+            data={calculatorData}
             points={points}
             repeatedEvent={repeatedEvent}
-            riskBudget={calculatorData.riskBudget}
             lowerBound={lowerBound}
             upperBound={upperBound}
           />


### PR DESCRIPTION
The only required fields in the form are duration and risk profile.

If either is missing, add a "Jump to error" link next to "Fill in calculator to see risk level" that scrolls to and highlights the missing value.