### PR TITLE
Fix risk profiles exceeding one million

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "root_files": [".watchmanconfig"]
+}

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,0 @@
-{
-  "root_files": [".watchmanconfig"]
-}

--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -4,6 +4,7 @@ import {
   calculate,
   calculateLocationPersonAverage,
   defaultValues,
+  ONE_MILLION,
 } from 'data/calculate'
 import {
   BUDGET_ONE_PERCENT,
@@ -214,6 +215,19 @@ describe('calculate', () => {
     expect(twoTimes?.expectedValue).toBeCloseTo(0.64e6)
     expect(twoTimes?.lowerBound).toBeCloseTo(248888.8, 0)
     expect(twoTimes?.upperBound).toBeCloseTo(1e6)
+  })
+
+  it('Should limit risk to one million', () => {
+    const data = testData({
+      ...baseTestData,
+      riskProfile: 'bars',
+      interaction: 'repeated',
+      personCount: 1,
+      casesPastWeek: 2000000,
+      population: '2,000,001',
+    })
+
+    expect(calcValue(data)).toBeLessThanOrEqual(ONE_MILLION)
   })
 
   it.each`

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -302,7 +302,7 @@ export const calculatePersonRiskEach = (
       data.percentFullyVaccinated === null ||
       data.averageFullyVaccinatedMultiplier === null
     ) {
-      return unadjustedRisk
+      return Math.min(unadjustedRisk, ONE_MILLION)
     }
     const fractionFullyVaccinated = data.percentFullyVaccinated / 100
     const unvaccinatedPrevalenceRatio =
@@ -315,15 +315,15 @@ export const calculatePersonRiskEach = (
     if (data.riskProfile === 'average') {
       switch (data.theirVaccine) {
         case 'vaccinated':
-          return (
+          return Math.min((
             unadjustedRisk *
             unvaccinatedPrevalenceRatio *
             data.averageFullyVaccinatedMultiplier
-          )
+          ), ONE_MILLION)
         case 'unvaccinated':
-          return unadjustedRisk * unvaccinatedPrevalenceRatio
+          return Math.min(unadjustedRisk * unvaccinatedPrevalenceRatio, ONE_MILLION)
         case 'undefined':
-          return unadjustedRisk
+          return Math.min(unadjustedRisk, ONE_MILLION)
         default:
           console.error(`Unrecognized vaccination state: ${data.theirVaccine}`)
           return null
@@ -332,16 +332,19 @@ export const calculatePersonRiskEach = (
       // These are risk profiles that were set up for unvaccinated people.
       switch (data.theirVaccine) {
         case 'vaccinated':
-          return unadjustedRisk * data.averageFullyVaccinatedMultiplier
+          return Math.min(
+            unadjustedRisk * data.averageFullyVaccinatedMultiplier,
+            ONE_MILLION,
+          )
         case 'unvaccinated':
-          return unadjustedRisk
+          return Math.min(unadjustedRisk, ONE_MILLION)
         case 'undefined':
           // data.unvaccinatedPrevalenceRatio is the average vaccine modifier
           // applied across the entire population, including unvaccinated
           // and partially vaccinated individuals.
           // See the comment above unvaccinated_relative_prevalence() in
           // update_prevalence.py for more details on how it is calculated.
-          return unadjustedRisk / unvaccinatedPrevalenceRatio
+          return Math.min(unadjustedRisk / unvaccinatedPrevalenceRatio, ONE_MILLION)
         default:
           console.error(`Unrecognized vaccination state: ${data.theirVaccine}`)
           return null

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -315,13 +315,17 @@ export const calculatePersonRiskEach = (
     if (data.riskProfile === 'average') {
       switch (data.theirVaccine) {
         case 'vaccinated':
-          return Math.min((
+          return Math.min(
             unadjustedRisk *
-            unvaccinatedPrevalenceRatio *
-            data.averageFullyVaccinatedMultiplier
-          ), ONE_MILLION)
+              unvaccinatedPrevalenceRatio *
+              data.averageFullyVaccinatedMultiplier,
+            ONE_MILLION,
+          )
         case 'unvaccinated':
-          return Math.min(unadjustedRisk * unvaccinatedPrevalenceRatio, ONE_MILLION)
+          return Math.min(
+            unadjustedRisk * unvaccinatedPrevalenceRatio,
+            ONE_MILLION,
+          )
         case 'undefined':
           return Math.min(unadjustedRisk, ONE_MILLION)
         default:
@@ -344,7 +348,10 @@ export const calculatePersonRiskEach = (
           // and partially vaccinated individuals.
           // See the comment above unvaccinated_relative_prevalence() in
           // update_prevalence.py for more details on how it is calculated.
-          return Math.min(unadjustedRisk / unvaccinatedPrevalenceRatio, ONE_MILLION)
+          return Math.min(
+            unadjustedRisk / unvaccinatedPrevalenceRatio,
+            ONE_MILLION,
+          )
         default:
           console.error(`Unrecognized vaccination state: ${data.theirVaccine}`)
           return null


### PR DESCRIPTION
This fixes #1310 by limiting the calculation in calculatePersonRiskEach to a maximum of one million.

