### PR TITLE
Fix J&J multipliers

### DIFF
--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -473,7 +473,8 @@ describe('calculate', () => {
       ${'astraZeneca'} | ${2}  | ${1}
       ${'astraZeneca'} | ${3}  | ${0.3}
       ${'johnson'}     | ${0}  | ${1}
-      ${'johnson'}     | ${1}  | ${0.95}
+      ${'johnson'}     | ${1}  | ${1}
+      ${'johnson'}     | ${2}  | ${0.95}
     `(
       '$doses doses of $type should give a multiplier of $multiplier',
       ({ type, doses, multiplier }) => {

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -383,7 +383,7 @@ export const Vaccines: { [key: string]: VaccineValue } = {
   },
   johnson: {
     label: i18n.t('data.vaccine.johnson_johnson'),
-    multiplierPerDose: [1, 0.95],
+    multiplierPerDose: [1, 1, 0.95],
   },
   sputnik: {
     label: i18n.t('data.vaccine.sputnik'),


### PR DESCRIPTION
J&J multiplier was mistakenly listed as .95x for 1 dose with no option for 2 doses. It should have been .95x for 2 doses and 1x for 1 dose.
https://www.medrxiv.org/content/10.1101/2021.12.28.21268436v1.full.pdf

Fixes: #1317