### PR TITLE
Warn, don't error, on cases without population.

### DIFF
--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1215,7 +1215,7 @@ def parse_jhu_daily_report(cache, data, current):
             "Unassigned",
             "Unknown",
         ):
-            raise ValueError(f"JHU data has cases but no population for {place!r} with line data: {line!r}")
+            print_and_log_to_sentry(f"JHU data has cases but no population for {place!r} with line data: {line!r}")
         place.cumulative_cases[current] = line.Confirmed
 
 


### PR DESCRIPTION
Fixes #1353.

When I run this manually, I get these two warnings (which would
previously cause the run to fail):
```
Discarding country Antarctica due to error: ValueError("Missing population data for Country(fullname='Antarctica', name='Antarctica', population=0, test_positivity_rate=None, cumulative_cases=Counter({datetime.date(2022, 2, 12): 11, datetime.date(2022, 2, 11): 11, datetime.date(2022, 2, 10): 11, datetime.date(2022, 2, 9): 11, datetime.date(2022, 2, 8): 11, datetime.date(2022, 2, 7): 11, datetime.date(2022, 2, 6): 11, datetime.date(2022, 2, 5): 11, datetime.date(2022, 2, 4): 11, datetime.date(2022, 2, 3): 11, datetime.date(2022, 2, 2): 11, datetime.date(2022, 2, 1): 11, datetime.date(2022, 1, 31): 11, datetime.date(2022, 1, 30): 11, datetime.date(2022, 1, 29): 11, datetime.date(2022, 1, 28): 11, datetime.date(2022, 1, 27): 11}), tests_in_past_week=None, vaccines_by_type=None, vaccines_total=Vaccination(partial_vaccinations=0, completed_vaccinations=0), iso3='ATA', states={})")
Discarding country Winter Olympics 2022 due to error: ValueError("Missing population data for Country(fullname='Winter Olympics 2022', name='Winter Olympics 2022', population=0, test_positivity_rate=None, cumulative_cases=Counter({datetime.date(2022, 2, 12): 498, datetime.date(2022, 2, 11): 490, datetime.date(2022, 2, 10): 465, datetime.date(2022, 2, 9): 465, datetime.date(2022, 2, 8): 465, datetime.date(2022, 2, 7): 459, datetime.date(2022, 2, 6): 435, datetime.date(2022, 2, 5): 425, datetime.date(2022, 2, 4): 380, datetime.date(2022, 2, 3): 359, datetime.date(2022, 2, 2): 304, datetime.date(2022, 2, 1): 272, datetime.date(2022, 1, 31): 248, datetime.date(2022, 1, 30): 211, datetime.date(2022, 1, 29): 177, datetime.date(2022, 1, 28): 141, datetime.date(2022, 1, 27): 129}), tests_in_past_week=None, vaccines_by_type=None, vaccines_total=Vaccination(partial_vaccinations=0, completed_vaccinations=0), iso3='', states={})")
```

I'm not sure if there's a case where these warnings really should be an
error, but for those two instances it seems like a warning is the right
thing to do.