### PR TITLE
Fix 'yarn lint' runs by updating 'black'

### DIFF
--- a/requirements-manual.txt
+++ b/requirements-manual.txt
@@ -1,4 +1,4 @@
 pydantic==1.8.2
 requests==2.25.1
-black==21.8b0
+black==22.3.0
 sentry-sdk==1.5.1


### PR DESCRIPTION
Update `black` to a version that does not rely on internal modules of `click`.  An internal module was removed from `click`, which broke `black`, which broke `yarn lint` when run from fresh dependencies.

See https://github.com/pallets/click/issues/2225 and https://github.com/psf/black/issues/2964