### PR TITLE
Allow back Micronesia and Palau

### DIFF
--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1316,8 +1316,6 @@ def ignore_jhu_place(line: JHUCommonFields) -> bool:
         "Grand Princess",
         "MS Zaandam",
         "Western Sahara",
-        "Micronesia",
-        "Palau",
         "Summer Olympics 2020",
         "Winter Olympics 2022",
         "Antarctica",


### PR DESCRIPTION
The lack of them is causing some WARNING logs:

```
WARNING: Could not find UID 583
WARNING: Could not find UID 585
```

I was able to run prevalence to completion, so I assume the original
issues that caused these places to be suppressed are resolved:

https://github.com/microCOVID/microCOVID/commit/f3d56e7c95abd69800e0f74b19653fb478bd1a71

https://github.com/microCOVID/microCOVID/commit/033d61c28f07d5f1ee624e52a498ac55088f2e67