### PR TITLE
Don't log when encountering known unknown locations from JHU

### DIFF
--- a/test_update_prevalence.py
+++ b/test_update_prevalence.py
@@ -5,6 +5,7 @@ from datetime import timedelta, date, datetime
 
 
 from update_prevalence import parse_jhu_vaccines_us, AllData, DataCache
+from logging import Logger
 import update_prevalence
 
 
@@ -28,3 +29,55 @@ def test_parse_jhu_vaccines_us(mock_get: typing.Any, mock_datetime: typing.Any) 
     parse_jhu_vaccines_us(cache, data)
 
     assert wyoming.vaccines_total.completed_vaccinations == 305397
+
+
+@patch("update_prevalence.logger", spec=Logger)
+@patch("update_prevalence.datetime")
+@patch("update_prevalence.requests.get", spec=requests.get)
+def test_parse_jhu_vaccines_us_known_unknown_state(
+    mock_get: typing.Any, mock_datetime: typing.Any, mock_logger: typing.Any
+) -> None:
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = """Date,UID,Province_State,Country_Region,Doses_admin,People_at_least_one_dose,People_fully_vaccinated,Total_additional_doses
+2022-12-02,84000056,Wyoming,US,835616,350112,305397,142731
+2022-12-02,84070022,Long Term Care (LTC) Program,US,7897367,4317892,3930082,2335790"""
+    mock_get.return_value = mock_response
+    mock_datetime.datetime.utcnow.return_value = 123
+    effective_date = date(2020, 12, 15)
+    update_prevalence.effective_date = effective_date
+    cache = DataCache(effective_date=effective_date, data={})
+    data = AllData()
+    # creates entry so next call doesn't fail
+    us = data.get_country("US")
+    # ditto
+    data.get_state("Wyoming", country="US")
+    parse_jhu_vaccines_us(cache, data)
+
+    mock_logger.warning.assert_not_called()
+
+
+@patch("update_prevalence.logger", spec=Logger)
+@patch("update_prevalence.datetime")
+@patch("update_prevalence.requests.get", spec=requests.get)
+def test_parse_jhu_vaccines_us_unknown_unknown_state(
+    mock_get: typing.Any, mock_datetime: typing.Any, mock_logger: typing.Any
+) -> None:
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = """Date,UID,Province_State,Country_Region,Doses_admin,People_at_least_one_dose,People_fully_vaccinated,Total_additional_doses
+2022-12-02,84000056,Wyoming,US,835616,350112,305397,142731
+2022-12-02,8675309,Some Unknown Entry,US,7897367,4317892,3930082,2335790"""
+    mock_get.return_value = mock_response
+    mock_datetime.datetime.utcnow.return_value = 123
+    effective_date = date(2020, 12, 15)
+    update_prevalence.effective_date = effective_date
+    cache = DataCache(effective_date=effective_date, data={})
+    data = AllData()
+    # creates entry so next call doesn't fail
+    us = data.get_country("US")
+    # ditto
+    data.get_state("Wyoming", country="US")
+    parse_jhu_vaccines_us(cache, data)
+
+    mock_logger.warning.assert_called()

--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1455,6 +1455,21 @@ def parse_jhu_vaccines_global(cache: DataCache, data: AllData) -> None:
         raise ValueError(f"Not able to gain data from {JHUVaccinesTimeseriesGlobal.SOURCE}")
 
 
+# JHU provides these as 'states' in time_series_covid19_vaccine_us.csv
+# but does not map back in UID_ISO_FIPS_LookUp_Table.csv
+#
+# Not being location-based categories, they wouldn't be helpful for
+# microCOVID users regardless, so silently ignore them.
+EXPECTED_MISSING_JHU_US_STATES = {
+    '', # Used to indicate all-of-USA values
+    'Department of Defense',
+    'Federal Bureau of Prisons',
+    'Indian Health Services',
+    'Long Term Care (LTC) Program',
+    'Veterans Health Administration',
+}
+
+
 def parse_jhu_vaccines_us(cache: DataCache, data: AllData) -> None:
     num_success = 0
     # US vaccination rates
@@ -1476,7 +1491,8 @@ def parse_jhu_vaccines_us(cache: DataCache, data: AllData) -> None:
         try:
             state = data.get_state_or_raise(name=item.Province_State, country=item.Country_Region)
         except KeyError:
-            print_and_log_to_sentry(f"Could not find state {item.Province_State}")
+            if item.Province_State not in EXPECTED_MISSING_JHU_US_STATES:
+                logger.warning(f"Could not find state {item.Province_State}")
             continue
             # Suppressed debug info - includes things like DoD, VHA, etc.
             # logger.warning(f"Could not find state {item.Province_State}")

--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1461,12 +1461,12 @@ def parse_jhu_vaccines_global(cache: DataCache, data: AllData) -> None:
 # Not being location-based categories, they wouldn't be helpful for
 # microCOVID users regardless, so silently ignore them.
 EXPECTED_MISSING_JHU_US_STATES = {
-    '', # Used to indicate all-of-USA values
-    'Department of Defense',
-    'Federal Bureau of Prisons',
-    'Indian Health Services',
-    'Long Term Care (LTC) Program',
-    'Veterans Health Administration',
+    "",  # Used to indicate all-of-USA values
+    "Department of Defense",
+    "Federal Bureau of Prisons",
+    "Indian Health Services",
+    "Long Term Care (LTC) Program",
+    "Veterans Health Administration",
 }
 
 


### PR DESCRIPTION
JHU provides these as 'states' in time_series_covid19_vaccine_us.csv
but does not map them back in UID_ISO_FIPS_LookUp_Table.csv

Not being location-based categories, they wouldn't be helpful for
microCOVID users regardless, so silently ignore them.