### PR TITLE
Fix up changelog and add entry in alerts section for #1421

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,8 +33,8 @@
       "delta_numbers": "<0>July 26th, 2021:</0> Updated for the Delta variant. Risks have increased substantially, including for vaccinated people. <2>Technical details here.</2>",
       "full_changelog": "see all updates…",
       "omicron_numbers": "<0>January 4th, 2022:</0> Updated for the Omicron variant. Vaccines without boosters are much less effective than before (but still prevent serious or fatal illness). <2>Technical details here.</2>",
-      "under_reporting_constants_changed": "<0>December 5th, 2022:</0> Updated constants for under-reporting factor.  New numbers from <2>COVID 19 Projections</2> March 2021 update.</2>",
-      "sputnik_added": "<0>April 10th, 2021:</0> Added the Sputnik V vaccine to the calculator. Learn more about our calculation of its efficacy <2>here</2>."
+      "sputnik_added": "<0>April 10th, 2021:</0> Added the Sputnik V vaccine to the calculator. Learn more about our calculation of its efficacy <2>here</2>.",
+      "under_reporting_constants_changed": "<0>December 5th, 2022:</0> Updated constants for under-reporting factor.  New numbers from <2>COVID 19 Projections</2> March 2021 update.</2>"
     },
     "baseline_risk": "baseline risk",
     "baseline_risk_short": "baseline",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,6 +33,7 @@
       "delta_numbers": "<0>July 26th, 2021:</0> Updated for the Delta variant. Risks have increased substantially, including for vaccinated people. <2>Technical details here.</2>",
       "full_changelog": "see all updates…",
       "omicron_numbers": "<0>January 4th, 2022:</0> Updated for the Omicron variant. Vaccines without boosters are much less effective than before (but still prevent serious or fatal illness). <2>Technical details here.</2>",
+      "under_reporting_constants_changed": "<0>December 5th, 2022:</0> Updated constants for under-reporting factor.  New numbers from <2>COVID 19 Projections</2> March 2021 update.</2>",
       "sputnik_added": "<0>April 10th, 2021:</0> Added the Sputnik V vaccine to the calculator. Learn more about our calculation of its efficacy <2>here</2>."
     },
     "baseline_risk": "baseline risk",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -222,6 +222,18 @@ export const Calculator = (): React.ReactElement => {
         </Col>
         <Col lg="4" md="12">
           <Alert className="changelog" variant="light">
+            <Trans i18nKey="calculator.alerts.under_reporting_constants_changed">
+              <strong>DATE_PLACEHOLDER</strong>{' '}
+              <a
+                href="https://covid19-projections.com/estimating-true-infections-revisited/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                HERE_PLACEHOLDER
+              </a>
+            </Trans>
+          </Alert>
+          <Alert className="changelog" variant="light">
             <Trans i18nKey="calculator.alerts.omicron_numbers">
               <strong>DATE_PLACEHOLDER</strong>{' '}
               <Link to="/paper/changelog">HERE_PLACEHOLDER</Link>

--- a/src/posts/paper/99-changelog.ts
+++ b/src/posts/paper/99-changelog.ts
@@ -11,9 +11,9 @@ const changes: Change[] = [
   {
     date: new Date(2022, 3, 12),
     content: `
-    * Updated constants for under-reporting factor
-      * New numbers from [COVID 19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/) March 2021 update.
-      `,
+* Updated constants for under-reporting factor
+  * New numbers from [COVID 19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/) March 2021 update.
+  `,
   },
   {
     date: new Date(2022, 0, 4),


### PR DESCRIPTION
The calculator changelog formatting was not showing up correctly, and
there was no entry in the alerts section for the
covid19-projections.com update.