### PR TITLE
Update link to Canadian health regions file

### DIFF
--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -376,7 +376,7 @@ class RomaniaPrevalenceData(pydantic.BaseModel):
 class CovidTimelineCanadaRegion(pydantic.BaseModel):
     SOURCE: ClassVar[
         str
-    ] = "https://raw.githubusercontent.com/ccodwg/CovidTimelineCanada/main/geo/health_regions.csv"
+    ] = "https://raw.githubusercontent.com/ccodwg/CovidTimelineCanada/main/geo/hr.csv"
 
     # two letter province/territory - e.g. AB
     region: str


### PR DESCRIPTION
Hello,

As part of an effort to improve the consistency of file naming in [`CovidTimelineCanada`](https://github.com/ccodwg/CovidTimelineCanada), the file `geo/health_regions.csv` has been renamed `geo/hr.csv`. The old file will exist as a duplicate for the foreseeable future, but I figured it was best to be proactive and open up at PR for this.

Note that I also added a "PRUID" column to the health regions file some time ago, but this doesn't seem to have disrupted your updates at all.

See ccodwg/CovidTimelineCanada#62 for more information