### PR TITLE
Update api.opencovid.ca call for HR case data

### DIFF
--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -392,7 +392,7 @@ class CovidTimelineCanadaRegion(pydantic.BaseModel):
 class CanadaOpenCovidCases(pydantic.BaseModel):
     SOURCE: ClassVar[
         str
-    ] = "https://api.opencovid.ca/timeseries?stat=cases&loc={hr_uid}&geo=hr&ymd=true&fill=true&before={before}&after={after}"
+    ] = "https://api.opencovid.ca/timeseries?stat=cases&loc={hr_uid}&geo=hr&date=19"
 
     class Data(pydantic.BaseModel):
         class Report(pydantic.BaseModel):
@@ -1685,9 +1685,7 @@ def parse_canada_prevalence_data(cache: DataCache, data: AllData) -> None:
                 cache,
                 CanadaOpenCovidCases,
                 CanadaOpenCovidCases.SOURCE.format(
-                    hr_uid=region.hruid,
-                    before=canada_effective_date.strftime("%Y-%m-%d"),
-                    after=populate_since.strftime("%Y-%m-%d"),
+                    hr_uid=region.hruid
                 ),
             )
             for report in case_reports.data.cases:


### PR DESCRIPTION
This PR is my attempt to address #1509.

Since transitioning to the `CovidTimelineCanada` dataset, the date structure of the dataset changed (see [Transitioning from `Covid19Canada`](https://github.com/ccodwg/CovidTimelineCanada/blob/main/docs/transitioning_from_Covid19Canada.md) for more details). Different PTs/HRs now have different end dates, based on their update schedules.

In this PR, I have made the following changes:

- The call for HR case data now returns the most recent 19 days of data available for that HR, and the "before" and "after" parameters have been removed.
- I did not touch the call for the PT summary data, since data in the `summary` route always ends with the current date, unlike the `timeseries` route.

I got 19 days by inspecting the provenience of the "before" and "after" variables:

https://github.com/microCOVID/microCOVID/blob/f1bbc621aca41126de2084cd14724840b72da7d0/update_prevalence.py#L1621-L1623

The "effective date" appears to be calculated as two days ago at most,

https://github.com/microCOVID/microCOVID/blob/f1bbc621aca41126de2084cd14724840b72da7d0/update_prevalence.py#L142-L147

...so 16 days before the effective date should be 19 days ago at most.

I am not familiar with the rest of the codebase, so I'm not sure if having different date ranges for different HR data (i.e., the most recent 7 days of data from Alberta and Manitoba will not be the same) will cause issues or not. If it's all index-based, it shouldn't cause issues.