### PR TITLE
Revert #1421

### DIFF
--- a/src/data/__tests__/calculate.test.ts
+++ b/src/data/__tests__/calculate.test.ts
@@ -79,11 +79,11 @@ describe('calculateLocationPersonAverage', () => {
   it.each`
     positiveCasePercentage | result
     ${0}                   | ${PREVALENCE}
-    ${4}                   | ${REPORTED_PREVALENCE * (0.04 ** 0.5 * 18.75 + 2)}
-    ${6}                   | ${REPORTED_PREVALENCE * (0.06 ** 0.5 * 18.75 + 2)}
-    ${16}                  | ${REPORTED_PREVALENCE * (0.16 ** 0.5 * 18.75 + 2)}
-    ${100}                 | ${REPORTED_PREVALENCE * (18.75 + 2)}
-    ${null}                | ${REPORTED_PREVALENCE * (18.75 + 2)}
+    ${4}                   | ${REPORTED_PREVALENCE * (0.04 ** 0.5 * 25 + 2)}
+    ${6}                   | ${REPORTED_PREVALENCE * (0.06 ** 0.5 * 25 + 2)}
+    ${16}                  | ${REPORTED_PREVALENCE * (0.16 ** 0.5 * 25 + 2)}
+    ${100}                 | ${REPORTED_PREVALENCE * (25 + 2)}
+    ${null}                | ${REPORTED_PREVALENCE * (25 + 2)}
   `(
     'should compensate for underreporting, positiveCasePercentage = $positiveCasePercentage',
     ({ positiveCasePercentage, result }) => {
@@ -95,12 +95,12 @@ describe('calculateLocationPersonAverage', () => {
 
   it.each`
     day    | result
-    ${0}   | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1500) / 50 + 2)}
-    ${25}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1500) / 75 + 2)}
-    ${50}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1500) / 100 + 2)}
-    ${300} | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1500) / 350 + 2)}
+    ${0}   | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1000) / 10 + 2)}
+    ${25}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1000) / 35 + 2)}
+    ${50}  | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1000) / 60 + 2)}
+    ${300} | ${REPORTED_PREVALENCE * ((0.25 ** 0.5 * 1000) / 310 + 2)}
   `(
-    'should reduce the effect of positiveCasePercentage as 1500 / (days + 50), days = $day',
+    'should reduce the effect of positiveCasePercentage as 1000 / (days + 10), days = $day',
     ({ day, result }) => {
       expect(
         calculateLocationPersonAverage(

--- a/src/data/calculate.ts
+++ b/src/data/calculate.ts
@@ -118,7 +118,7 @@ const prevalenceRatio = (positivityPercent: number | null, date: Date) => {
     positivityPercent = 100
   }
   const positivityRate = positivityPercent / 100
-  return (1500 / (day_i + 50)) * positivityRate ** 0.5 + 2
+  return (1000 / (day_i + 10)) * positivityRate ** 0.5 + 2
 }
 
 // These are the variables exposed via query parameters

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,8 +33,7 @@
       "delta_numbers": "<0>July 26th, 2021:</0> Updated for the Delta variant. Risks have increased substantially, including for vaccinated people. <2>Technical details here.</2>",
       "full_changelog": "see all updates…",
       "omicron_numbers": "<0>January 4th, 2022:</0> Updated for the Omicron variant. Vaccines without boosters are much less effective than before (but still prevent serious or fatal illness). <2>Technical details here.</2>",
-      "sputnik_added": "<0>April 10th, 2021:</0> Added the Sputnik V vaccine to the calculator. Learn more about our calculation of its efficacy <2>here</2>.",
-      "under_reporting_constants_changed": "<0>December 5th, 2022:</0> Updated constants for under-reporting factor.  New numbers from <2>COVID 19 Projections</2> March 2021 update.</2>"
+      "sputnik_added": "<0>April 10th, 2021:</0> Added the Sputnik V vaccine to the calculator. Learn more about our calculation of its efficacy <2>here</2>."
     },
     "baseline_risk": "baseline risk",
     "baseline_risk_short": "baseline",

--- a/src/pages/Calculator.tsx
+++ b/src/pages/Calculator.tsx
@@ -222,18 +222,6 @@ export const Calculator = (): React.ReactElement => {
         </Col>
         <Col lg="4" md="12">
           <Alert className="changelog" variant="light">
-            <Trans i18nKey="calculator.alerts.under_reporting_constants_changed">
-              <strong>DATE_PLACEHOLDER</strong>{' '}
-              <a
-                href="https://covid19-projections.com/estimating-true-infections-revisited/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                HERE_PLACEHOLDER
-              </a>
-            </Trans>
-          </Alert>
-          <Alert className="changelog" variant="light">
             <Trans i18nKey="calculator.alerts.omicron_numbers">
               <strong>DATE_PLACEHOLDER</strong>{' '}
               <Link to="/paper/changelog">HERE_PLACEHOLDER</Link>

--- a/src/posts/paper/7-basic-method.ts
+++ b/src/posts/paper/7-basic-method.ts
@@ -58,7 +58,7 @@ You can use the _positive test rate_ (the percentage of tests that come back COV
 
 If you live in the US, you can look up the positive test rate in your state at [CovidActNow](https://covidactnow.org).
 
-We use the correction factor proposed by [COVID-19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/)[^15]:
+We use the correction factor proposed by [COVID-19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/):
 \`\`\`
 prevalance_ratio = 1250 / (day_i + 25) * positive_test_rate ** 0.5 + 2
 true_infections = prevalance_ratio * reported_infections
@@ -148,9 +148,6 @@ Compare this with San Francisco County in California, which had [749 new reporte
 
 [^14]:
      If Reasonable Rosie keeps up this rate of 369 microCOVIDs per week, she’ll incur about 20,000 microCOVIDs per year, which implies about a 2% chance of getting COVID during that year. This is lower than the average American, but is too high for comfort for some people!
-
-[^15]:
-     Since the original white paper, this has been [updated](https://github.com/microCOVID/microCOVID/pull/1421) to the 2021-03 model update from the author.
 
 [^essential]: By “essential worker” we mean roughly the same thing as the following two definitions. First: “Frontline workers include, but are not limited to, healthcare workers, protective service workers (police and EMTs), cashiers in grocery and general merchandise stores, production and food processing workers, janitors and maintenance workers, agricultural workers, and truck drivers” ([econofact.org](https://econofact.org/essential-and-frontline-workers-in-the-covid-19-crisis)). Second: “Essential workers are those who must leave their home to do their jobs AND: who interact in person with members of the public; OR who cannot maintain social distancing at their jobs; OR who work directly with people who are homeless or who have serious medical conditions or who are over age 60” (originally from [color.com](https://www.reddit.com/r/sanfrancisco/comments/gacw9v/covid19_testing_sites_falling_short_of_5000_test/)).
 

--- a/src/posts/paper/99-changelog.ts
+++ b/src/posts/paper/99-changelog.ts
@@ -9,13 +9,6 @@ interface Change {
 
 const changes: Change[] = [
   {
-    date: new Date(2022, 3, 12),
-    content: `
-    * Updated constants for under-reporting factor
-      * New numbers from [COVID 19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/) March 2021 update.
-      `,
-  },
-  {
     date: new Date(2022, 0, 4),
     title: 'Omicron variant vaccine updates',
     content: `

--- a/src/posts/paper/99-changelog.ts
+++ b/src/posts/paper/99-changelog.ts
@@ -11,9 +11,9 @@ const changes: Change[] = [
   {
     date: new Date(2022, 3, 12),
     content: `
-* Updated constants for under-reporting factor
-  * New numbers from [COVID 19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/) March 2021 update.
-  `,
+    * Updated constants for under-reporting factor
+      * New numbers from [COVID 19 Projections](https://covid19-projections.com/estimating-true-infections-revisited/) March 2021 update.
+      `,
   },
   {
     date: new Date(2022, 0, 4),

--- a/test_update_prevalence.py
+++ b/test_update_prevalence.py
@@ -405,7 +405,7 @@ def test_AppLocation_prevalenceRatio_caps_positivity_rate(
     effective_date: date,
 ) -> None:
     my_app_location.positiveCasePercentage = 150
-    assert my_app_location.prevalenceRatio() == 6.089309878213803
+    assert my_app_location.prevalenceRatio() == 3.430615164520744
 
 
 def test_AllData_get_country_or_raise_raises() -> None:

--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -867,19 +867,14 @@ class AppLocation(pydantic.BaseModel, PopulationFilteredLogging):
     def prevalenceRatio(self) -> float:
         DAY_0 = datetime(2020, 2, 12)
         day_i = (datetime.now() - DAY_0).days
-        positivityRate = self.positiveCasePercentage or 100
-
-        if positivityRate > 100:
+        positivityRate = self.positiveCasePercentage
+        if positivityRate is None or positivityRate > 100:
             positivityRate = 100
-
         if positivityRate < 0:
             self.issue("Positivity rate is negative", f"{positivityRate}")
             positivityRate = 0
-
-        testingUnavailabilityCoefficient = 1500 / (day_i + 50)
-        positivityInferredPrevelenceRatio = (positivityRate / 100) ** 0.5 + 2
-
-        return testingUnavailabilityCoefficient * positivityInferredPrevelenceRatio
+        final = (1000 / (day_i + 10)) * (positivityRate / 100) ** 0.5 + 2
+        return final
 
     @property
     def population_as_int(self) -> int:


### PR DESCRIPTION
This reverts #1421 until we can validate the change further.

The PR changed our prevalence ratio formula from:
`1000/(day_i + 50) * (positivity-rate)^0.5 + 1`
to
`1500/(day_i + 50) * (positivity-rate)^0.5 + 1`

However, I do not believe that reflects the actual March 2, 2021 update on the referenced paper.  In fact, I believe it rolls us back to a formula used prior to the December 10th, 2020 update:

> December 10, 2020 Update: We adjusted the constant in the prevalence ratio formula from a = 1500 / (day_i + 50) to a = 1000 / (day_i + 10). This results in a slightly higher prevalence ratio in the beginning of the pandemic and a lower prevalence ratio currently.

I believe that the author of the PR assumed that the update notices at the top of the paper indicated that the contents had been updated, noticed that the formula inside didn't match our formula, and changed our formula to match.  I believe that the contents of the paper had not actually changed for many of the listed updates, and the updates instead referred to the actual live model website the paper described.  

Here’s the page prior to the March 2, 2021 update:

https://web.archive.org/web/20210227192800/https://covid19-projections.com/estimating-true-infections-revisited/

and here it is today:

https://covid19-projections.com/estimating-true-infections-revisited/

Notice that the paper uses the `1500/(day_i + 50) * (positivity-rate)^0.5 + 1` formula in both.
