### PR TITLE
Remove fetches from JHU for unused days of history

### DIFF
--- a/test_update_prevalence.py
+++ b/test_update_prevalence.py
@@ -667,8 +667,6 @@ def test_main_empty_data(
         mock_jhu_daily_report,
         mock_jhu_daily_report,
         mock_jhu_daily_report,
-        mock_jhu_daily_report,
-        mock_jhu_daily_report,
         mock_jhu_daily_report,  # 12-02-2020
         mock_jhu_daily_report,  # 12-01-2020
         mock_jhu_daily_report,  # 11-30-2020

--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1822,10 +1822,9 @@ def main() -> None:
         data.populate_fips_cache()
 
         # Cumulative cases per region
-        # adding one as the API compares with '>'
-        populate_since = effective_date - timedelta(days=NUM_DAYS_OF_HISTORY + 1)
+        populate_from = effective_date - timedelta(days=NUM_DAYS_OF_HISTORY - 1)
         current = effective_date
-        while current >= populate_since:
+        while current >= populate_from:
             parse_jhu_daily_report(cache, data, current)
             current -= timedelta(days=1)
 


### PR DESCRIPTION
It looks like a sign error resulted in two more days of JHU daily reports being pulled than are actually used in the application.

Verified by:
* ensuring that we have an exception raised when fewer than 8 of days are used to calculate a week's cases (see asserts in https://github.com/microCOVID/microCOVID/pull/1722).
* Running update_prevalence.py before and after and verifying no changes in data generated.

This was an inconsistency that was holding back refactors in how we deal with history fetching.