### PR TITLE
Remove fetches from api.covid19tracker.ca for unused days of history

### DIFF
--- a/update_prevalence.py
+++ b/update_prevalence.py
@@ -1645,8 +1645,7 @@ def parse_romania_prevalence_data(cache: DataCache, data: AllData) -> None:
 
 
 def parse_canada_prevalence_data(cache: DataCache, data: AllData) -> None:
-    # adding one as the API compares with '>'
-    populate_since = canada_effective_date - timedelta(days=NUM_DAYS_OF_HISTORY + 1)
+    populate_since = canada_effective_date - timedelta(days=NUM_DAYS_OF_HISTORY - 1)
     canada_one_week_ago = canada_effective_date - timedelta(days=6)
 
     try:


### PR DESCRIPTION
Similar to JHU in https://github.com/microCOVID/microCOVID/pull/1724, it looks like a sign error resulted in two more days of api.covid19tracker.ca daily reports being pulled than are actually used in the application.

Verified by:
* ensuring that we have an exception raised when fewer than 8 of days are used to calculate a week's cases (see asserts in https://github.com/microCOVID/microCOVID/pull/1722).
* Running update_prevalence.py before and after and verifying no changes in data generated.