### PR TITLE
#1826 - Manual prevalence entry v1 proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# environment
+.env
+.idea
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
+++ b/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
@@ -18,7 +18,10 @@ const PrevalenceField: React.FunctionComponent<{
   max?: number
   min?: number
   helpText?: string
+  warningText?: string
+  showWarningText?: boolean
   className?: string
+  rowClassName?: string
   readOnly?: boolean
 }> = ({
   id,
@@ -32,6 +35,9 @@ const PrevalenceField: React.FunctionComponent<{
   helpText,
   className,
   readOnly,
+  warningText,
+  showWarningText,
+  rowClassName,
 }): React.ReactElement => {
   let body: React.ReactElement = (
     <Form.Control
@@ -63,7 +69,7 @@ const PrevalenceField: React.FunctionComponent<{
     )
   }
   return (
-    <Row>
+    <Row className={rowClassName}>
       <Form.Group controlId={id} className="mb-3">
         <ControlLabel
           id={`${id}-control-label`}
@@ -75,6 +81,9 @@ const PrevalenceField: React.FunctionComponent<{
           }
         />
         {body}
+        {showWarningText && warningText ? (
+          <div className="mt-3 text-danger">{warningText}</div>
+        ) : null}
       </Form.Group>
     </Row>
   )
@@ -121,11 +130,14 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           setter={(value) => props.setter({ ...props.data, population: value })}
           inputType="text"
           className="hide-number-buttons"
+          warningText="Warning: if you are entering cases per 100,000, this field should be set to 100,000"
+          showWarningText={props.data.population !== '100000'}
         />
         <PrevalenceField
           id="percent-increase"
           label={t('calculator.prevalence.percent_increase_in_cases')}
-          value={props.data.casesIncreasingPercentage}
+          // value={props.data.casesIncreasingPercentage}
+          value={0} // this field is no longer adjustable
           unit="%"
           setter={(value) => {
             props.setter({
@@ -136,15 +148,17 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           inputType="number"
           min={0}
           className="hide-number-buttons"
+          rowClassName="d-none"
         />
         <PrevalenceField
           id="positive-test-rate"
           label={t('calculator.prevalence.positive_case_percentage')}
-          value={
-            props.data.positiveCasePercentage
-              ? props.data.positiveCasePercentage.toString()
-              : ''
-          }
+          // value={
+          //   props.data.positiveCasePercentage
+          //     ? props.data.positiveCasePercentage.toString()
+          //     : ''
+          // }
+          value={'10'} // this field is no longer adjustable
           unit="%"
           setter={(value) => {
             props.setter({
@@ -156,15 +170,17 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           max={100}
           min={0}
           className="hide-number-buttons"
+          rowClassName="d-none"
         />
         <PrevalenceField
           id="vaccinated-rate"
           label={t('calculator.prevalence.completed_vaccinations')}
-          value={
-            props.data.percentFullyVaccinated
-              ? props.data.percentFullyVaccinated.toString()
-              : ''
-          }
+          // value={
+          //   props.data.percentFullyVaccinated
+          //     ? props.data.percentFullyVaccinated.toString()
+          //     : ''
+          // }
+          value={'0'} // this field is no longer adjustable
           unit="%"
           setter={(value) => {
             props.setter({
@@ -176,6 +192,7 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           max={100}
           min={0}
           className="hide-number-buttons"
+          rowClassName="d-none"
           readOnly={props.data.unvaccinatedPrevalenceRatio !== null}
           helpText={
             props.data.unvaccinatedPrevalenceRatio !== null

--- a/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
+++ b/src/components/calculator/prevalence/ManualPrevalenceDetails.tsx
@@ -117,7 +117,7 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           setter={(value) =>
             props.setter({
               ...props.data,
-              casesPastWeek: parseInt(value || ''),
+              casesPastWeek: parseFloat(value || ''),
             })
           }
           inputType="number"
@@ -131,7 +131,9 @@ export const ManualPrevalenceDetails: React.FunctionComponent<{
           inputType="text"
           className="hide-number-buttons"
           warningText="Warning: if you are entering cases per 100,000, this field should be set to 100,000"
-          showWarningText={props.data.population !== '100000'}
+          showWarningText={
+            parseInt(props.data.population.replace(/,/g, '')) !== 100000
+          }
         />
         <PrevalenceField
           id="percent-increase"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -186,7 +186,7 @@
       "data_last_updated": "Data last updated",
       "details_header": "Details",
       "instructions": "<p>The microCOVID calculator's data source is no longer providing updates on COVID rates. To use the calculator, please look up <strong>weekly new cases per 100k</strong> in your area and enter it below. Then enter \"100,000\" in the \"total population\" box. The other boxes can be left on their defaults.</p><p>We hope to have a more usable version of the interface in place soon. Contact info@microcovid.org with any questions.</p><p><i>If you are in the US, go to <0>covidactnow.org</0>, click your state on the map, then your county. The first number on the screen is \"weekly new reported cases per 100k\".</p>",
-      "last_week_cases": "Reported cases in past week",
+      "last_week_cases": "Weekly new cases / 100k population",
       "percent_increase_in_cases": "Percent increase in cases from last week to this week",
       "population": "Total population",
       "positive_case_percentage": "Percent of tests that come back positive",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,7 +185,7 @@
       "completed_vaccinations_tooltip": "This field is only editable if we are missing vaccination data for your location",
       "data_last_updated": "Data last updated",
       "details_header": "Details",
-      "instructions": "<p>The microCOVID calculator's data source is no longer providing updates on COVID rates. To use the calculator, please look up <strong>weekly new cases per 100k</strong> in your area and enter it below. Then enter \"100,000\" in the \"total population\" box. The other boxes can be left on their defaults.</p><p>We hope to have a more usable version of the interface in place soon. Contact info@microcovid.org with any questions.</p><p><i>If you are in the US, go to <0>covidactnow.org</0>, click your state on the map, then your county. The first number on the screen is \"weekly new reported cases per 100k\".</p>",
+      "instructions": "<p>The microCOVID calculator's data source is no longer providing updates on COVID rates. To use the calculator, please look up <strong>weekly new cases per 100k</strong> in your area and enter it below. Then enter \"100,000\" in the \"total population\" box.</p><p>We hope to have a more usable version of the interface in place soon. Contact info@microcovid.org with any questions.</p><p><i>If you are in the US, go to <0>covidactnow.org</0>, click your state on the map, then your county. The first number on the screen is \"weekly new reported cases per 100k\".</p>",
       "last_week_cases": "Weekly new cases / 100k population",
       "percent_increase_in_cases": "Percent increase in cases from last week to this week",
       "population": "Total population",


### PR DESCRIPTION
- Please see [here](https://github.com/microCOVID/microCOVID/issues/1826) for source of changes.
- Hide specific fields from view (but keep in the page)
- Hardcode some of the newly hidden values so that all previous values are "wiped out" and are not affecting the calculation
- Show a Warning if Population field is not exactly 100k.